### PR TITLE
refactor: extract mapping_issues to main

### DIFF
--- a/autoware_lanelet2_map_validator/src/common/validation.cpp
+++ b/autoware_lanelet2_map_validator/src/common/validation.cpp
@@ -283,8 +283,8 @@ lanelet::validation::ValidationConfig replace_validator(
   return temp;
 }
 
-void process_requirements(
-  json json_data, const MetaConfig & validator_config, const lanelet::LaneletMap & lanelet_map)
+std::vector<lanelet::validation::DetectedIssues> validate_all_requirements(
+  json & json_data, const MetaConfig & validator_config, const lanelet::LaneletMap & lanelet_map)
 {
   std::vector<lanelet::validation::DetectedIssues> total_issues;
   std::regex issue_code_pattern(R"(\[(.+?)\]\s*(.+))");
@@ -357,21 +357,19 @@ void process_requirements(
     appendIssues(total_issues, issues);
   }
 
-  // Show results
-  summarize_validator_results(json_data);
-  lanelet::validation::printAllIssues(total_issues);
+  return total_issues;
+}
 
-  // Save results
-  if (!validator_config.output_file_path.empty()) {
-    if (!std::filesystem::is_directory(validator_config.output_file_path)) {
-      throw std::invalid_argument("Output path doesn't exist or is not a directory!");
-    }
-    std::filesystem::path file_directory = validator_config.output_file_path;
-    std::filesystem::path file_path = file_directory / "lanelet2_validation_results.json";
-    std::ofstream output_file(file_path);
-    output_file << std::setw(4) << json_data;
-    std::cout << "Results are output to " << file_path << std::endl;
+void export_results(json & json_data, const std::string output_file_path)
+{
+  if (!std::filesystem::is_directory(output_file_path)) {
+    throw std::invalid_argument("Output path doesn't exist or is not a directory!");
   }
+  std::filesystem::path file_directory = output_file_path;
+  std::filesystem::path file_path = file_directory / "lanelet2_validation_results.json";
+  std::ofstream output_file(file_path);
+  output_file << std::setw(4) << json_data;
+  std::cout << "Results are output to " << file_path << std::endl;
 }
 
 }  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validation.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validation.hpp
@@ -68,9 +68,11 @@ void summarize_validator_results(json & json_data);
 lanelet::validation::ValidationConfig replace_validator(
   const lanelet::validation::ValidationConfig & input, const std::string & validator_name);
 
-void process_requirements(
-  json json_data, const lanelet::autoware::validation::MetaConfig & validator_config,
+std::vector<lanelet::validation::DetectedIssues> validate_all_requirements(
+  json & json_data, const lanelet::autoware::validation::MetaConfig & validator_config,
   const lanelet::LaneletMap & lanelet_map);
+
+void export_results(json & json_data, const std::string output_file_path);
 }  // namespace lanelet::autoware::validation
 
 #endif  // LANELET2_MAP_VALIDATOR__VALIDATION_HPP_

--- a/autoware_lanelet2_map_validator/src/main.cpp
+++ b/autoware_lanelet2_map_validator/src/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
     lanelet::validation::printAllIssues(loading_issues);
   }
 
-  // Validattion against lanelet::LaneletMap object
+  // Validation against lanelet::LaneletMap object
   if (!lanelet_map_ptr) {
     throw std::invalid_argument("The map file was not possible to load!");
   } else if (!meta_config.requirements_file.empty()) {


### PR DESCRIPTION
## Description

This re-factorization is aimed to extract validation issues to the main process, and declare the visualization in the main process.  This is because there are future plans to use the validation issues in other kinds of tasks, in addition, it is difficult to reflect loading/parsing issues to the output with the current system.

The main changes are
- Changed confusing names
  - Function `process_requirements` to `validate_all_requirements`
  - Variable `map_issue` to `loading_issues`
- Bring the visualization process `summarize_validator_results` to main
- Extract the JSON exportation process as `export_results`.
- There was a code
  ```cpp
  if (!lanelet_map_ptr) {
    lanelet::validation::printAllIssues(map_issue);
  }
  ```
  but detecting a loading issue doesn't mean `lanelet_map_ptr` to be nullptr. (It sometimes just ignores that primitive.)
  So I change the way to print `loading_issues` (previously `map_issue`) and throw an error if `lanelet_map_ptr` went something wrong.

## How was this PR tested?

- [x] Checked `colcon test` works as usual.
- [x] Checked normal usages work as usual.

## Notes for reviewers

None.

## Effects on system behavior

None.
