### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/autoware_lanelet2_map_validator/CHANGELOG.rst
+++ b/autoware_lanelet2_map_validator/CHANGELOG.rst
@@ -25,19 +25,19 @@ Changelog for package autoware_lanelet2_map_validator
 * added test code for version control functions
 * apply verions to package and autoware_requirement_set.json
 * add feature of version control
-* chore: bump version to 0.1.0 (`#209 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/209>`_)
+* chore: bump version to 0.1.0 (`#209 <https://github.com/autowarefoundation/autoware_tools/issues/209>`_)
   * remove COLCON_IGNORE
   * unify version to 0.0.0
   * add changelog
   * 0.1.0
   * remove stop_accel_evaluator
   ---------
-* feat(lanelet2_map_validator): check local coordinates declaration (`#194 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/194>`_)
+* feat(lanelet2_map_validator): check local coordinates declaration (`#194 <https://github.com/autowarefoundation/autoware_tools/issues/194>`_)
   * Implement mapping.lane.local_coordinates_declaration
   * Added test for mapping.lane.local_coordinates_declaration
   * Added documents for mapping.lane.local_coordinates_declaration
   ---------
-* feat(lanelet2_map_validator): add validator to check whether intersection lanelets have valid turn_direction tags (`#186 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/186>`_)
+* feat(lanelet2_map_validator): add validator to check whether intersection lanelets have valid turn_direction tags (`#186 <https://github.com/autowarefoundation/autoware_tools/issues/186>`_)
   * Added validator which checks the "turn_direction" tag in intersection_areas
   * Added test code for mapping.intersection.turn_direction_tagging
   * Added document for mapping.intersection.turn_direction_tagging
@@ -45,18 +45,18 @@ Changelog for package autoware_lanelet2_map_validator
   * Fixed spelling errors
   * Removed crosswalk boundaries from test map
   ---------
-* docs(lanelet2_map_validator): update README (`#193 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/193>`_)
+* docs(lanelet2_map_validator): update README (`#193 <https://github.com/autowarefoundation/autoware_tools/issues/193>`_)
   * Updated document
   * Added explanation about issue_code
   * Removed back ticks in the title
   * Fixed spelling issues
   ---------
-* fix(lanelet2_map_validator): restore missing intersection lane and removed unnecessary linestrings from intersection test maps (`#188 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/188>`_)
+* fix(lanelet2_map_validator): restore missing intersection lane and removed unnecessary linestrings from intersection test maps (`#188 <https://github.com/autowarefoundation/autoware_tools/issues/188>`_)
   * Restore missing linestring 197 and lanelet 49
   * Removed crosswalk remainings from intersection category test maps
   ---------
-* docs(autoware_lanelet2_map_validator): update usage (`#191 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/191>`_)
-* feat(lanelet2_map_validator): generation script for new validators (`#180 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/180>`_)
+* docs(autoware_lanelet2_map_validator): update usage (`#191 <https://github.com/autowarefoundation/autoware_tools/issues/191>`_)
+* feat(lanelet2_map_validator): generation script for new validators (`#180 <https://github.com/autowarefoundation/autoware_tools/issues/180>`_)
   * temporary commit
   * Added python script
   * Finished except docs
@@ -71,15 +71,15 @@ Changelog for package autoware_lanelet2_map_validator
   * Added back slashes to example command
   * Enable the generation script to be run by `ros2 run`
   ---------
-* chore(lanelet2_map_validator): automate test code compilation and categorize test codes (`#183 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/183>`_)
+* chore(lanelet2_map_validator): automate test code compilation and categorize test codes (`#183 <https://github.com/autowarefoundation/autoware_tools/issues/183>`_)
   * Categorize test codes
   * Rewrite CMakeLists.txt so that contributors doesn't have to write the test code name in it
   ---------
-* feat(autoware_lanelet_map_validator): add dangling reference checker to non existing intersection_area (`#177 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/177>`_)
-* chore: sync files (`#11 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/11>`_)
+* feat(autoware_lanelet_map_validator): add dangling reference checker to non existing intersection_area (`#177 <https://github.com/autowarefoundation/autoware_tools/issues/177>`_)
+* chore: sync files (`#11 <https://github.com/autowarefoundation/autoware_tools/issues/11>`_)
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lanelet2_map_validator): check whether intersection_area satisfies vm-03-08 (`#171 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/171>`_)
+* feat(lanelet2_map_validator): check whether intersection_area satisfies vm-03-08 (`#171 <https://github.com/autowarefoundation/autoware_tools/issues/171>`_)
   * Create the framework for intersection_area_validity.
   * Made is_valid checker in intersection_area_validity
   * Split and create a new validator intersection_area_segement_type.
@@ -93,7 +93,7 @@ Changelog for package autoware_lanelet2_map_validator
   * Removed original bbox calculation and use the one in the Lanelet2 library
   * Added explanation of functions
   ---------
-* docs(lanelet2_map_validator): add a new document how_to_contribute.md (`#170 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/170>`_)
+* docs(lanelet2_map_validator): add a new document how_to_contribute.md (`#170 <https://github.com/autowarefoundation/autoware_tools/issues/170>`_)
   * Added a document how_to_contribute.md to lanelet2_map_validator
   * Added information about CMakeLists in tests.
   * Added figure illustrating the input output
@@ -105,14 +105,14 @@ Changelog for package autoware_lanelet2_map_validator
   * Quit using .. to direct to README.md
   * Fixed link mistakes
   ---------
-* Fixed issue that invalid prerequisites are not reflected to the results (`#169 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/169>`_)
-* feat(lanelet2_map_validator): add validator to check traffic light facing (`#165 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/165>`_)
+* Fixed issue that invalid prerequisites are not reflected to the results (`#169 <https://github.com/autowarefoundation/autoware_tools/issues/169>`_)
+* feat(lanelet2_map_validator): add validator to check traffic light facing (`#165 <https://github.com/autowarefoundation/autoware_tools/issues/165>`_)
   * Added valdiator missing_referrers_for_traffic_lights
   * Added validator traffic_light_facing
   * Added traffic_light_facing and missing_referrers_for_traffic_lights
   * Added new validators to README.md
   * Added test codes for traffic_light_facing and missing_referrers_for_traffic_lights
-  * feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/163>`_)
+  * feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/autowarefoundation/autoware_tools/issues/163>`_)
   * Added issue code processing
   * Revised tests for json processing
   * Added issue codes for missing_regulatory_elements_for_crosswalks
@@ -140,7 +140,7 @@ Changelog for package autoware_lanelet2_map_validator
   ---------
   Co-authored-by: Mamoru Sobue <hilo.soblin@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/163>`_)
+* feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/autowarefoundation/autoware_tools/issues/163>`_)
   * Added issue code processing
   * Revised tests for json processing
   * Added issue codes for missing_regulatory_elements_for_crosswalks
@@ -152,7 +152,7 @@ Changelog for package autoware_lanelet2_map_validator
   * Change issue_code_prefix to append_issue_code_prefix
   * Fixed merging mistake
   ---------
-* feat(lanelet2_map_validator): add test codes for existing validators (`#150 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/150>`_)
+* feat(lanelet2_map_validator): add test codes for existing validators (`#150 <https://github.com/autowarefoundation/autoware_tools/issues/150>`_)
   * Added small maps for testing.
   Added test codes using these maps.
   * Rearrange architecture of test directory.
@@ -165,14 +165,14 @@ Changelog for package autoware_lanelet2_map_validator
   * Fixed detection area in sample_map.osm
   * Added autoware namespace to test codes
   ---------
-* refactor(lalenet2_map_validator): divide map loading process (`#153 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/153>`_)
-* refactor(lanelet2_map_validator): move custom implementation to lanelet::autoware::validation (`#152 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/152>`_)
-* fix(lanelet2_map_validator): change validation order in regulatory_elements_details (`#151 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/151>`_)
+* refactor(lalenet2_map_validator): divide map loading process (`#153 <https://github.com/autowarefoundation/autoware_tools/issues/153>`_)
+* refactor(lanelet2_map_validator): move custom implementation to lanelet::autoware::validation (`#152 <https://github.com/autowarefoundation/autoware_tools/issues/152>`_)
+* fix(lanelet2_map_validator): change validation order in regulatory_elements_details (`#151 <https://github.com/autowarefoundation/autoware_tools/issues/151>`_)
   * Changed the order to validate in regulatory_element_details
   * Revised test code
   ---------
-* Removed redundant appendIssues (`#148 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/148>`_)
-* feat(autoware_lanelet2_map_validator): allow prerequisites attribute for input (`#147 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/147>`_)
+* Removed redundant appendIssues (`#148 <https://github.com/autowarefoundation/autoware_tools/issues/148>`_)
+* feat(autoware_lanelet2_map_validator): allow prerequisites attribute for input (`#147 <https://github.com/autowarefoundation/autoware_tools/issues/147>`_)
   * Added prerequisites tag to input.
   Moved process_requirements to validation.cpp
   * Added prerequisites to autoware_requirement_set.json
@@ -187,19 +187,19 @@ Changelog for package autoware_lanelet2_map_validator
   * Reflect PR comments
   * Fixed typo
   ---------
-* refactor(lanelet2_map_validator): move headers to include/ (`#144 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/144>`_)
-* chore(autoware_lanelet2_map_validator): add requirement vm-02-02 to autoware_requirement_set (`#143 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/143>`_)
+* refactor(lanelet2_map_validator): move headers to include/ (`#144 <https://github.com/autowarefoundation/autoware_tools/issues/144>`_)
+* chore(autoware_lanelet2_map_validator): add requirement vm-02-02 to autoware_requirement_set (`#143 <https://github.com/autowarefoundation/autoware_tools/issues/143>`_)
   * Add Sobue-san as maintainer of autoware_lanelet2_map_validator
   * Added maintainers to autoware_lanelet2_map_validator
   * Added vm-02-02 to autoware_requirement_set.json
   * Fixed error of autoware_lanelet2_map_validator template
   * Detect stop lines that are referred as `refers` role.
   ---------
-* chore(autoware_lanelet2_map_validator): add maintainers (`#141 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/141>`_)
+* chore(autoware_lanelet2_map_validator): add maintainers (`#141 <https://github.com/autowarefoundation/autoware_tools/issues/141>`_)
   * Add Sobue-san as maintainer of autoware_lanelet2_map_validator
   * Added maintainers to autoware_lanelet2_map_validator
   ---------
-* feat(autoware_lanelet2_map_validator): introduce autoware_lanelet2_map_validator (`#118 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/118>`_)
+* feat(autoware_lanelet2_map_validator): introduce autoware_lanelet2_map_validator (`#118 <https://github.com/autowarefoundation/autoware_tools/issues/118>`_)
   * introduce autoware_lanelet2_map_validator to autoware_tools
   * wrote description a little to README.md
   * style(pre-commit): autofix

--- a/autoware_lanelet2_map_validator/CHANGELOG.rst
+++ b/autoware_lanelet2_map_validator/CHANGELOG.rst
@@ -2,8 +2,15 @@
 Changelog for package autoware_lanelet2_map_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1.0.1 (2025-02-18)
+1.1.0 (2025-02-28)
 ------------------
+* feat: follow to the latest vm-05-01 (`#26 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/26>`_)
+* Contributors: TaikiYamada4
+
+1.0.1 (2025-02-20)
+------------------
+* chore: bump version to 1.0.1 (`#24 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/24>`_)
+  Co-authored-by: github-actions <github-actions@github.com>
 * docs: fix internal links (`#20 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/20>`_)
 * chore: move docs into autoware_lanelet2_map_validator directory (`#18 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/18>`_)
 * refactor: extract mapping_issues to main (`#13 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/13>`_)
@@ -18,19 +25,19 @@ Changelog for package autoware_lanelet2_map_validator
 * added test code for version control functions
 * apply verions to package and autoware_requirement_set.json
 * add feature of version control
-* chore: bump version to 0.1.0 (`#209 <https://github.com/autowarefoundation/autoware_tools/issues/209>`_)
+* chore: bump version to 0.1.0 (`#209 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/209>`_)
   * remove COLCON_IGNORE
   * unify version to 0.0.0
   * add changelog
   * 0.1.0
   * remove stop_accel_evaluator
   ---------
-* feat(lanelet2_map_validator): check local coordinates declaration (`#194 <https://github.com/autowarefoundation/autoware_tools/issues/194>`_)
+* feat(lanelet2_map_validator): check local coordinates declaration (`#194 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/194>`_)
   * Implement mapping.lane.local_coordinates_declaration
   * Added test for mapping.lane.local_coordinates_declaration
   * Added documents for mapping.lane.local_coordinates_declaration
   ---------
-* feat(lanelet2_map_validator): add validator to check whether intersection lanelets have valid turn_direction tags (`#186 <https://github.com/autowarefoundation/autoware_tools/issues/186>`_)
+* feat(lanelet2_map_validator): add validator to check whether intersection lanelets have valid turn_direction tags (`#186 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/186>`_)
   * Added validator which checks the "turn_direction" tag in intersection_areas
   * Added test code for mapping.intersection.turn_direction_tagging
   * Added document for mapping.intersection.turn_direction_tagging
@@ -38,18 +45,18 @@ Changelog for package autoware_lanelet2_map_validator
   * Fixed spelling errors
   * Removed crosswalk boundaries from test map
   ---------
-* docs(lanelet2_map_validator): update README (`#193 <https://github.com/autowarefoundation/autoware_tools/issues/193>`_)
+* docs(lanelet2_map_validator): update README (`#193 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/193>`_)
   * Updated document
   * Added explanation about issue_code
   * Removed back ticks in the title
   * Fixed spelling issues
   ---------
-* fix(lanelet2_map_validator): restore missing intersection lane and removed unnecessary linestrings from intersection test maps (`#188 <https://github.com/autowarefoundation/autoware_tools/issues/188>`_)
+* fix(lanelet2_map_validator): restore missing intersection lane and removed unnecessary linestrings from intersection test maps (`#188 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/188>`_)
   * Restore missing linestring 197 and lanelet 49
   * Removed crosswalk remainings from intersection category test maps
   ---------
-* docs(autoware_lanelet2_map_validator): update usage (`#191 <https://github.com/autowarefoundation/autoware_tools/issues/191>`_)
-* feat(lanelet2_map_validator): generation script for new validators (`#180 <https://github.com/autowarefoundation/autoware_tools/issues/180>`_)
+* docs(autoware_lanelet2_map_validator): update usage (`#191 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/191>`_)
+* feat(lanelet2_map_validator): generation script for new validators (`#180 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/180>`_)
   * temporary commit
   * Added python script
   * Finished except docs
@@ -64,15 +71,15 @@ Changelog for package autoware_lanelet2_map_validator
   * Added back slashes to example command
   * Enable the generation script to be run by `ros2 run`
   ---------
-* chore(lanelet2_map_validator): automate test code compilation and categorize test codes (`#183 <https://github.com/autowarefoundation/autoware_tools/issues/183>`_)
+* chore(lanelet2_map_validator): automate test code compilation and categorize test codes (`#183 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/183>`_)
   * Categorize test codes
   * Rewrite CMakeLists.txt so that contributors doesn't have to write the test code name in it
   ---------
-* feat(autoware_lanelet_map_validator): add dangling reference checker to non existing intersection_area (`#177 <https://github.com/autowarefoundation/autoware_tools/issues/177>`_)
-* chore: sync files (`#11 <https://github.com/autowarefoundation/autoware_tools/issues/11>`_)
+* feat(autoware_lanelet_map_validator): add dangling reference checker to non existing intersection_area (`#177 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/177>`_)
+* chore: sync files (`#11 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/11>`_)
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lanelet2_map_validator): check whether intersection_area satisfies vm-03-08 (`#171 <https://github.com/autowarefoundation/autoware_tools/issues/171>`_)
+* feat(lanelet2_map_validator): check whether intersection_area satisfies vm-03-08 (`#171 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/171>`_)
   * Create the framework for intersection_area_validity.
   * Made is_valid checker in intersection_area_validity
   * Split and create a new validator intersection_area_segement_type.
@@ -86,7 +93,7 @@ Changelog for package autoware_lanelet2_map_validator
   * Removed original bbox calculation and use the one in the Lanelet2 library
   * Added explanation of functions
   ---------
-* docs(lanelet2_map_validator): add a new document how_to_contribute.md (`#170 <https://github.com/autowarefoundation/autoware_tools/issues/170>`_)
+* docs(lanelet2_map_validator): add a new document how_to_contribute.md (`#170 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/170>`_)
   * Added a document how_to_contribute.md to lanelet2_map_validator
   * Added information about CMakeLists in tests.
   * Added figure illustrating the input output
@@ -98,14 +105,14 @@ Changelog for package autoware_lanelet2_map_validator
   * Quit using .. to direct to README.md
   * Fixed link mistakes
   ---------
-* Fixed issue that invalid prerequisites are not reflected to the results (`#169 <https://github.com/autowarefoundation/autoware_tools/issues/169>`_)
-* feat(lanelet2_map_validator): add validator to check traffic light facing (`#165 <https://github.com/autowarefoundation/autoware_tools/issues/165>`_)
+* Fixed issue that invalid prerequisites are not reflected to the results (`#169 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/169>`_)
+* feat(lanelet2_map_validator): add validator to check traffic light facing (`#165 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/165>`_)
   * Added valdiator missing_referrers_for_traffic_lights
   * Added validator traffic_light_facing
   * Added traffic_light_facing and missing_referrers_for_traffic_lights
   * Added new validators to README.md
   * Added test codes for traffic_light_facing and missing_referrers_for_traffic_lights
-  * feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/autowarefoundation/autoware_tools/issues/163>`_)
+  * feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/163>`_)
   * Added issue code processing
   * Revised tests for json processing
   * Added issue codes for missing_regulatory_elements_for_crosswalks
@@ -133,7 +140,7 @@ Changelog for package autoware_lanelet2_map_validator
   ---------
   Co-authored-by: Mamoru Sobue <hilo.soblin@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/autowarefoundation/autoware_tools/issues/163>`_)
+* feat(lanelet2_map_validator): added issue codes  (`#163 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/163>`_)
   * Added issue code processing
   * Revised tests for json processing
   * Added issue codes for missing_regulatory_elements_for_crosswalks
@@ -145,7 +152,7 @@ Changelog for package autoware_lanelet2_map_validator
   * Change issue_code_prefix to append_issue_code_prefix
   * Fixed merging mistake
   ---------
-* feat(lanelet2_map_validator): add test codes for existing validators (`#150 <https://github.com/autowarefoundation/autoware_tools/issues/150>`_)
+* feat(lanelet2_map_validator): add test codes for existing validators (`#150 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/150>`_)
   * Added small maps for testing.
   Added test codes using these maps.
   * Rearrange architecture of test directory.
@@ -158,14 +165,14 @@ Changelog for package autoware_lanelet2_map_validator
   * Fixed detection area in sample_map.osm
   * Added autoware namespace to test codes
   ---------
-* refactor(lalenet2_map_validator): divide map loading process (`#153 <https://github.com/autowarefoundation/autoware_tools/issues/153>`_)
-* refactor(lanelet2_map_validator): move custom implementation to lanelet::autoware::validation (`#152 <https://github.com/autowarefoundation/autoware_tools/issues/152>`_)
-* fix(lanelet2_map_validator): change validation order in regulatory_elements_details (`#151 <https://github.com/autowarefoundation/autoware_tools/issues/151>`_)
+* refactor(lalenet2_map_validator): divide map loading process (`#153 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/153>`_)
+* refactor(lanelet2_map_validator): move custom implementation to lanelet::autoware::validation (`#152 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/152>`_)
+* fix(lanelet2_map_validator): change validation order in regulatory_elements_details (`#151 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/151>`_)
   * Changed the order to validate in regulatory_element_details
   * Revised test code
   ---------
-* Removed redundant appendIssues (`#148 <https://github.com/autowarefoundation/autoware_tools/issues/148>`_)
-* feat(autoware_lanelet2_map_validator): allow prerequisites attribute for input (`#147 <https://github.com/autowarefoundation/autoware_tools/issues/147>`_)
+* Removed redundant appendIssues (`#148 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/148>`_)
+* feat(autoware_lanelet2_map_validator): allow prerequisites attribute for input (`#147 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/147>`_)
   * Added prerequisites tag to input.
   Moved process_requirements to validation.cpp
   * Added prerequisites to autoware_requirement_set.json
@@ -180,19 +187,19 @@ Changelog for package autoware_lanelet2_map_validator
   * Reflect PR comments
   * Fixed typo
   ---------
-* refactor(lanelet2_map_validator): move headers to include/ (`#144 <https://github.com/autowarefoundation/autoware_tools/issues/144>`_)
-* chore(autoware_lanelet2_map_validator): add requirement vm-02-02 to autoware_requirement_set (`#143 <https://github.com/autowarefoundation/autoware_tools/issues/143>`_)
+* refactor(lanelet2_map_validator): move headers to include/ (`#144 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/144>`_)
+* chore(autoware_lanelet2_map_validator): add requirement vm-02-02 to autoware_requirement_set (`#143 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/143>`_)
   * Add Sobue-san as maintainer of autoware_lanelet2_map_validator
   * Added maintainers to autoware_lanelet2_map_validator
   * Added vm-02-02 to autoware_requirement_set.json
   * Fixed error of autoware_lanelet2_map_validator template
   * Detect stop lines that are referred as `refers` role.
   ---------
-* chore(autoware_lanelet2_map_validator): add maintainers (`#141 <https://github.com/autowarefoundation/autoware_tools/issues/141>`_)
+* chore(autoware_lanelet2_map_validator): add maintainers (`#141 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/141>`_)
   * Add Sobue-san as maintainer of autoware_lanelet2_map_validator
   * Added maintainers to autoware_lanelet2_map_validator
   ---------
-* feat(autoware_lanelet2_map_validator): introduce autoware_lanelet2_map_validator (`#118 <https://github.com/autowarefoundation/autoware_tools/issues/118>`_)
+* feat(autoware_lanelet2_map_validator): introduce autoware_lanelet2_map_validator (`#118 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/118>`_)
   * introduce autoware_lanelet2_map_validator to autoware_tools
   * wrote description a little to README.md
   * style(pre-commit): autofix

--- a/autoware_lanelet2_map_validator/package.xml
+++ b/autoware_lanelet2_map_validator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lanelet2_map_validator</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>Validation tool for lanelet2 maps especially for Autoware usage</description>
   <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>


### PR DESCRIPTION
## Description

This PR bumps the version of autoware_lanelet2_map_validator to 1.1.0.
I'll create a new release and tag after this PR is merged.

## How was this PR tested?

None.

## Notes for reviewers

None.

## Effects on system behavior

None.
