### PR TITLE
feat: create ValidatorConfigStore to read parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Not all validators have parameters so take a look at the documents in [autoware_
 | `-x, --exclusion_list`     | Path to the JSON file where the list of primitives to exclude is written                                                                                        |
 | `-v, --validator`          | Comma separated list of regexes to filter the applicable validators. Will run all validators by default. Example: `mapping.*` to run all checks for the mapping |
 | `-p, --projector`          | Projector used for loading lanelet map. Available projectors are: `mgrs`, `utm`, and `transverse_mercator`.                                                     |
+| `--parameters`             | Path to the YAML file where the list of parameters is written. `config/params.yaml` will be used if not specified                                               |
 | `-l, --location`           | Location of the map (for instantiating the traffic rules), e.g. de for Germany (currently not used)                                                             |
 | `--participants`           | Participants for which the routing graph will be instantiated (default: vehicle) (currently not used)                                                           |
 | `--lat`                    | latitude coordinate of map origin. This is required for the transverse mercator and utm projector.                                                              |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator --print
 
 ### Advanced usages
 
+#### Exclusion List
+
 You can input an "exclusion list" to `autoware_lanelet2_map_validator` to inform what primitive to ignore during the validation.
 Add the `--exclusion_list` or `-x` option to the command to pass the exclusion list (JSON format) like the example below.
 This option works for both usages above.
@@ -188,6 +190,11 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator \
 -o ./
 -x ./my_exclusion_list.json
 ```
+
+#### Parameters
+
+If the validator you want to modify parameters, you can change them in [autoware_lanelet2_map_validator/config/params.yaml](./autoware_lanelet2_map_validator/config/params.yaml).
+Not all validators have parameters so take a look at the documents in [autoware_lanelet2_map_validator/docs](./autoware_lanelet2_map_validator/docs/) to check whether the validator has parameters and how do they work.
 
 ### Available command options
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -208,6 +208,7 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator \
 | `-x, --exclusion_list`     | JSON 形式の除外リストのファイルパス                                                                                                        |
 | `-v, --validator`          | カンマ区切りおよび正規表現で与えられた検証器のみを実行する。例えば、 `mapping.*` と指定すると `mapping` から始まる全ての検証器を実行する。 |
 | `-p, --projector`          | Lanelet2 地図の投影法。　`mgrs`, `utm`, `transverse_mercator` から選択。                                                                   |
+| `--parameters`             | パラメータを格納する YAML ファイルのパス。指定されなければデフォルトで `config/params.yaml` を用いる。                                     |
 | `-l, --location`           | 地図の場所に関する情報 (未使用)                                                                                                            |
 | `--participants`           | 自動車や歩行者など交通ルールの対象の指定 (未使用)                                                                                          |
 | `--lat`                    | 地図原点の緯度。 これは transverse mercator 投影法や utm 投影法で用いる。                                                                  |

--- a/README_ja.md
+++ b/README_ja.md
@@ -175,6 +175,8 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator --print
 
 ### その他応用例
 
+#### 除外リスト
+
 `autoware_lanelet2_map_validator`は「除外リスト」を一緒に入力することで、どの地図要素を検証対象としないかを指定することができます。
 除外リストは `--exclusion_list` もしくは `-x` オプションで渡すことができます（下のコマンド例参照）。
 上記で説明された両使用方法に対して適用することが可能です。
@@ -188,6 +190,11 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator \
 -o ./
 -x ./my_exclusion_list.json
 ```
+
+#### パラメータ
+
+もしも使用する検証器がパラメータを持つ場合は、[autoware_lanelet2_map_validator/config/params.yaml](./autoware_lanelet2_map_validator/config/params.yaml)で変更することができます。
+全ての検証器がパラメータを持っているわけではないので、各検証器のドキュメント [autoware_lanelet2_map_validator/docs](./autoware_lanelet2_map_validator/docs/) を参照して、パラメータがあるか、そしてそれがどのようなパラメータであるかを確認してください。
 
 ### オプション一覧
 

--- a/autoware_lanelet2_map_validator/CMakeLists.txt
+++ b/autoware_lanelet2_map_validator/CMakeLists.txt
@@ -80,5 +80,6 @@ install(
 ament_auto_package(
   INSTALL_TO_SHARE
   test/data
+  config
   map_requirements
 )

--- a/autoware_lanelet2_map_validator/CMakeLists.txt
+++ b/autoware_lanelet2_map_validator/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_find_build_dependencies()
 find_package(nlohmann_json REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 file(GLOB_RECURSE autoware_lanelet2_map_validator_lib_src
   src/common/*.cpp
@@ -22,6 +23,10 @@ target_include_directories(
 )
 
 ament_target_dependencies(autoware_lanelet2_map_validator_lib nlohmann_json)
+
+target_link_libraries(autoware_lanelet2_map_validator_lib
+  yaml-cpp
+)
 
 ament_auto_add_executable(autoware_lanelet2_map_validator
   src/main.cpp

--- a/autoware_lanelet2_map_validator/config/params.yaml
+++ b/autoware_lanelet2_map_validator/config/params.yaml
@@ -1,0 +1,2 @@
+mapping.lane.border_sharing:
+  iou_threshold: 0.05

--- a/autoware_lanelet2_map_validator/docs/how_to_contribute.md
+++ b/autoware_lanelet2_map_validator/docs/how_to_contribute.md
@@ -143,6 +143,22 @@ If you feel typing these arguments exhausting, you can overwrite the `default` v
 - Currently, there are no rules to decide the severity of the issue. If you're not confident about your severity decisions please discuss them with your PR reviewers.
 - Other coding rules are mentioned in the [Autoware Documentation](https://autowarefoundation.github.io/autoware-documentation/main/contributing/). However, this coding rule doesn't hold if it conflicts with the Lanelet2 library.
 
+#### Parameters
+
+If your validator needs parameters, you can add them to [config/params.yaml](../config/params.yaml).
+Then, call [ValidatorConfigStore::parameters()](../src/include/lanelet2_map_validator/config_store.hpp) to get all the parameters from `params.yaml`.
+`ValidatorConfigStore::parameters()[\<name of validator\>]` will return the parameters for your validator only.
+You can call this code anywhere in your implementation.
+The parameters can be defined in the YAML map format like the following.
+
+```yaml
+mapping.category.validator_name:
+  parameter_a: 0.5
+  parameter_b: true
+```
+
+Note that you should declare the validator's name first and then write the parameters below it.
+
 ### 2. Write a test code
 
 Contributors must also provide test codes to ensure your validator is working properly and be able to be tested again when changes occur to the validator in the future.

--- a/autoware_lanelet2_map_validator/docs/lane/border_sharing.md
+++ b/autoware_lanelet2_map_validator/docs/lane/border_sharing.md
@@ -69,6 +69,14 @@ In Autoware, lanelets are intended to be unidirectional. Therefore, when we want
 
 This is why we have the IoU (intersection over union) calculation for conflicting lanelets since the expanded the polygon will cover the border of other lanelets. We assume that if the IoU is higher than 0.05 and the polygon covers the border linestring, it is likely to be pseudo-bidirectional lanelets like this case. In other words, this validator only judges a pair of lanelets to be adjacent when they have a small IoU.
 
+## Parameters
+
+This validator has the following parameter.
+
+| Parameter     | Default Value | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| iou_threshold | 0.05          | The threshold to distinguish whether the overlap of the extended polygon and the candidate lanelet is not large enough to infer that it is intentional. If the IoU is smaller than this value, the validator assume that they are physically adjacent. For a numerical example, the IoU will be about 0.024 if there are two adjacent rectangles with the same shape and one of them have expanded from the center of 5 %. |
+
 ## Related source codes
 
 - border_sharing.cpp

--- a/autoware_lanelet2_map_validator/package.xml
+++ b/autoware_lanelet2_map_validator/package.xml
@@ -25,6 +25,7 @@
   <depend>lanelet2_validation</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pugixml-dev</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
 

--- a/autoware_lanelet2_map_validator/src/common/cli.cpp
+++ b/autoware_lanelet2_map_validator/src/common/cli.cpp
@@ -54,6 +54,9 @@ MetaConfig parseCommandLine(int argc, const char * argv[])
     "Projector used for loading lanelet map. Available projectors are: mgrs, utm, "
     "transverse_mercator. (default: mgrs)"
   )(
+    "parameters", po::value<std::string>(),
+    "Path to the YAML file where a list of parameters is written"
+  )(
     "location,l", po::value(&validation_config.location)->default_value(validation_config.location),
     "Location of the map (for instantiating the traffic rules), e.g. de for Germany"
   )(
@@ -62,11 +65,11 @@ MetaConfig parseCommandLine(int argc, const char * argv[])
   )(
     "lat", po::value(&validation_config.origin.lat)->default_value(validation_config.origin.lat),
     "Latitude coordinate of map origin. This is required for the transverse mercator "
-    "and utm projector."
+    "and utm projector"
   )(
     "lon", po::value(&validation_config.origin.lon)->default_value(validation_config.origin.lon),
     "Longitude coordinate of map origin. This is required for the transverse mercator "
-    "and utm projector."
+    "and utm projector"
   )(
     "print", "Print all available checker without running them"
   );
@@ -91,6 +94,9 @@ MetaConfig parseCommandLine(int argc, const char * argv[])
   }
   if (vm.count("exclusion_list") != 0) {
     config.exclusion_list = vm["exclusion_list"].as<std::string>();
+  }
+  if (vm.count("parameters") != 0) {
+    config.parameters_file = vm["parameters"].as<std::string>();
   }
   if (
     (vm.count("lat") != 0 && vm.count("lon") != 0) &&

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/cli.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/cli.hpp
@@ -31,6 +31,7 @@ struct MetaConfig
   std::string requirements_file;
   std::string output_file_path;
   std::string exclusion_list;
+  std::string parameters_file;
 };
 
 MetaConfig parseCommandLine(int argc, const char * argv[]);

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/config_store.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/config_store.hpp
@@ -1,0 +1,54 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VALIDATOR__CONFIG_STORE_HPP_
+#define LANELET2_MAP_VALIDATOR__CONFIG_STORE_HPP_
+
+#include <nlohmann/json.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace lanelet::autoware::validation
+{
+
+class ValidatorConfigStore
+{
+public:
+  static void initialize(
+    const std::string & params_yaml_file, const std::string & issues_info_json_file)
+  {
+    yaml_ = YAML::LoadFile(params_yaml_file);
+
+    std::ifstream json_ifs(issues_info_json_file);
+    if (!json_ifs.is_open()) {
+      throw std::runtime_error("Failed to open JSON file: " + issues_info_json_file);
+    }
+    json_ifs >> json_;
+  }
+
+  static const YAML::Node & parameters() { return yaml_; }
+  static const nlohmann::json & issues_info() { return json_; }
+
+private:
+  static inline YAML::Node yaml_;
+  static inline nlohmann::json json_;
+};
+
+}  // namespace lanelet::autoware::validation
+
+#endif  // LANELET2_MAP_VALIDATOR__CONFIG_STORE_HPP_

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/border_sharing.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/border_sharing.hpp
@@ -15,6 +15,8 @@
 #ifndef LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__BORDER_SHARING_HPP_
 #define LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__BORDER_SHARING_HPP_
 
+#include "lanelet2_map_validator/config_store.hpp"
+
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/GenericTrafficRules.h>
 #include <lanelet2_validation/Validation.h>
@@ -32,6 +34,12 @@ public:
 
   lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
 
+  BorderSharingValidator()
+  {
+    const auto parameters = ValidatorConfigStore::parameters()[name()];
+    iou_threshold_ = get_parameter_or<double>(parameters, "iou_threshold", 0.05);
+  }
+
 private:
   lanelet::validation::Issues check_border_sharing(const lanelet::LaneletMap & map);
   lanelet::BasicPolygon2d expanded_lanelet_polygon(
@@ -41,6 +49,8 @@ private:
     const lanelet::ConstLanelet to);
   double intersection_over_union(
     const lanelet::BasicPolygon2d & polygon1, const lanelet::BasicPolygon2d & polygon2);
+
+  double iou_threshold_;
 };
 
 namespace traffic_rules

--- a/autoware_lanelet2_map_validator/src/main.cpp
+++ b/autoware_lanelet2_map_validator/src/main.cpp
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "lanelet2_map_validator/cli.hpp"
+#include "lanelet2_map_validator/config_store.hpp"
 #include "lanelet2_map_validator/io.hpp"
 #include "lanelet2_map_validator/map_loader.hpp"
 #include "lanelet2_map_validator/utils.hpp"
 #include "lanelet2_map_validator/validation.hpp"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
@@ -90,6 +92,18 @@ int main(int argc, char * argv[])
       exclusion_map[validator_name] = std::vector<lanelet::autoware::validation::SimplePrimitive>();
     }
   }
+
+  // Load parameters and issues_info files
+  std::string package_share_directory =
+    ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
+  std::string parameters_file = (!meta_config.parameters_file.empty())
+                                  ? meta_config.parameters_file
+                                  : package_share_directory + "/config/params.yaml";
+  std::string issues_info_file =
+    package_share_directory +
+    "/config/issues_info.json";  // We think issues_info should NOT be derived for now
+  lanelet::autoware::validation::ValidatorConfigStore::initialize(
+    parameters_file, issues_info_file);
 
   // Validation against lanelet::LaneletMap object
   if (!lanelet_map_ptr) {

--- a/autoware_lanelet2_map_validator/src/main.cpp
+++ b/autoware_lanelet2_map_validator/src/main.cpp
@@ -99,11 +99,7 @@ int main(int argc, char * argv[])
   std::string parameters_file = (!meta_config.parameters_file.empty())
                                   ? meta_config.parameters_file
                                   : package_share_directory + "/config/params.yaml";
-  std::string issues_info_file =
-    package_share_directory +
-    "/config/issues_info.json";  // We think issues_info should NOT be derived for now
-  lanelet::autoware::validation::ValidatorConfigStore::initialize(
-    parameters_file, issues_info_file);
+  lanelet::autoware::validation::ValidatorConfigStore::initialize(parameters_file);
 
   // Validation against lanelet::LaneletMap object
   if (!lanelet_map_ptr) {

--- a/autoware_lanelet2_map_validator/src/validators/lane/border_sharing.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/lane/border_sharing.cpp
@@ -87,7 +87,7 @@ lanelet::validation::Issues BorderSharingValidator::check_border_sharing(
       if (
         relation == lanelet::routing::RelationType::Conflicting &&
         intersection_over_union(surrounding_polygon, candidate_lane.polygon2d().basicPolygon()) >
-          0.05) {
+          iou_threshold_) {
         continue;
       }
 

--- a/autoware_lanelet2_map_validator/template/validator_template.md
+++ b/autoware_lanelet2_map_validator/template/validator_template.md
@@ -12,6 +12,10 @@ Feature explanation here.
 | ---------- | ------- | -------- | --------- | ----------- | -------- |
 |            |         |          |           |             |          |
 
+## Parameters
+
+None.
+
 ## Related source codes
 
 - validator_template.cpp

--- a/autoware_lanelet2_map_validator/test/src/test_parameter_loading.cpp
+++ b/autoware_lanelet2_map_validator/test/src/test_parameter_loading.cpp
@@ -42,12 +42,7 @@ TEST_F(ParameterLoadingTest, CheckDefaultParamsFileHasValidValidators)
   lanelet::validation::Strings validators =
     lanelet::validation::availabeChecks("");  // cspell:disable-line
 
-  const std::string package_share_directory =
-    ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
-  const std::string full_path = package_share_directory + "/config/params.yaml";
-  YAML::Node root = YAML::LoadFile(full_path);
-
-  for (const auto & child : root) {
+  for (const auto & child : params) {
     std::string child_name = child.first.as<std::string>();
     EXPECT_TRUE(std::find(validators.begin(), validators.end(), child_name) != validators.end());
   }

--- a/autoware_lanelet2_map_validator/test/src/test_parameter_loading.cpp
+++ b/autoware_lanelet2_map_validator/test/src/test_parameter_loading.cpp
@@ -1,0 +1,56 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "map_validation_tester.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <nlohmann/json.hpp>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace lanelet::autoware::validation
+{
+
+class ParameterLoadingTest : public MapValidationTester
+{
+protected:
+};
+
+TEST_F(ParameterLoadingTest, CheckDefaultParamsFileHasValidValidators)
+{
+  const auto params = ValidatorConfigStore::parameters();
+  load_target_map("sample_map.osm");  // Needed to provoke validator registration
+
+  lanelet::validation::Strings validators =
+    lanelet::validation::availabeChecks("");  // cspell:disable-line
+
+  const std::string package_share_directory =
+    ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
+  const std::string full_path = package_share_directory + "/config/params.yaml";
+  YAML::Node root = YAML::LoadFile(full_path);
+
+  for (const auto & child : root) {
+    std::string child_name = child.first.as<std::string>();
+    EXPECT_TRUE(std::find(validators.begin(), validators.end(), child_name) != validators.end());
+  }
+}
+
+}  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/test/src/traffic_light/test_regulatory_elements_details_for_traffic_lights.cpp
+++ b/autoware_lanelet2_map_validator/test/src/traffic_light/test_regulatory_elements_details_for_traffic_lights.cpp
@@ -48,13 +48,19 @@ TEST_F(TestRegulatoryElementDetailsForTrafficLights, MissingRefers)  // NOLINT f
   bool found_error_on_loading = false;
   int target_primitive_id = 1025;
   std::string target_message =
-    "Error parsing primitive " + std::to_string(target_primitive_id) +
+    "\t- Error parsing primitive " + std::to_string(target_primitive_id) +
     ": Creating a regulatory element of type traffic_light failed: No traffic light defined!";
 
-  for (const auto & error : loading_errors_) {
-    if (error.find(target_message) != std::string::npos) {
-      found_error_on_loading = true;
-      break;
+  const lanelet::validation::Issue expected_issue(
+    lanelet::validation::Severity::Error, lanelet::validation::Primitive::Point, lanelet::InvalId,
+    target_message);
+
+  for (const auto & detected_issues : loading_issues_) {
+    for (const auto & issue : detected_issues.issues) {
+      if (is_same_issue(issue, expected_issue)) {
+        found_error_on_loading = true;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This is a rework of https://github.com/tier4/autoware_lanelet2_map_validator/pull/35.

This PR adds a parameter loader class `ValidatorConfigStore` to the autoware_lanelet2_map_validator.
This class will read parameters from the `config/params.yaml` file at first of the validation, and then validators can retrieve their parameters by `ValidatorConfigStore::parameters()`.
While the previous PR (https://github.com/tier4/autoware_lanelet2_map_validator/pull/35) cannot get parameters from external files, this PR can.

Since the current autoware_lanelet2_map_validator doesn't have validator that needs parameters, I set the threshold of IoU in the `mapping.lane.border_sharing` as a parameter for demonstration.

Hence, this PR does the following.
1. Adds a new class `ValidatorConfigStore`
2. Adds a new file `config/params.yaml`
3. Adds new option  `--parameters` to the CLI so that autoware_lanelet2_map_validator can retrieve parameters from user-defined param files.
   1. By default, it will read the `config/params.yaml` file by its own.
4. Lets `mapping.lane.border_sharing` use the parameter feature.
5. Adds information to documents about parameters.
6. Adds test codes to validate whether the `config/params.yaml`
   1. Refactored the map loading mechanism in the test codes (See Notes for reviewers)

## How was this PR tested?

- Checked that colcon test passes
- Checked that `mapping.lane.border_sharing` works and the number of issues will change if the parameter `iou_threshold` changes
    - First, I've created a copy of `params.yaml` outside, change the `iou_threshold`, and run the command below.
    - The larger the threshold will be, the more the issues appear. (False positive will increase.)

```bash
ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator -p mgrs -m ~/autoware_map/my_map.osm -v "mapping.lane.border_sharing" --parameters copy_of_params.yaml
```

## Notes for reviewers

- The `ValidatorConfigStore` will soon store `issues_info` and `language` to be able to output multilingual issue messages. This also benefits that the information of issues will be defined as a JSON(?) file and solid writing of issue messages in the source code will be gone.
- I've used `lanelet::autoware::validation::loadAndValidateMap` rather than `lanelet::load` to load test maps in the test code. This is because I need to provoke static registration of validators in parameter loading test. I'm still not sure why this work but didn't come with a better idea.
  - Due this change, I've changed the name of variable loading_errors_ to loading_issues_ to avoid confusion, which also leads to the refactoring of test_regulatory_elements_details_for_traffic_lights.cpp.

## Effects on system behavior

The autoware_lanelet2_map_validator will read parameters, if the `config/params.yaml` doesn't exist somehow the validation will stop.
