### PR TITLE
feat: add validation_info to the lanelet2_validation_results.json

### DIFF
--- a/autoware_lanelet2_map_validator/src/common/io.cpp
+++ b/autoware_lanelet2_map_validator/src/common/io.cpp
@@ -14,7 +14,10 @@
 
 #include "lanelet2_map_validator/io.hpp"
 
+#include "lanelet2_map_validator/cli.hpp"
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <nlohmann/json.hpp>
 #include <pugixml.hpp>
 
 #include <filesystem>
@@ -89,5 +92,21 @@ void insert_validator_info_to_map(
   }
 
   std::cout << "Modified validator information in the osm file." << std::endl;
+}
+
+void insert_validation_info_to_json(nlohmann::json & json_data, MetaConfig config)
+{
+  const std::filesystem::path path(config.command_line_config.mapFile);
+  const std::string map_file_name =
+    path.parent_path().filename().string() + "/" + path.filename().string();
+  const std::string requirements_file_name =
+    std::filesystem::path(config.requirements_file).filename().string();
+
+  json_data["validation_info"] = {
+    {"target_map", map_file_name},
+    {"map_requirements",
+     {{"filename", requirements_file_name}, {"version", json_data.value("version", "")}}},
+    {"validator",
+     {{"name", "autoware_lanelet2_map_validator"}, {"version", get_validator_version()}}}};
 }
 }  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/io.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/io.hpp
@@ -15,6 +15,10 @@
 #ifndef LANELET2_MAP_VALIDATOR__IO_HPP_
 #define LANELET2_MAP_VALIDATOR__IO_HPP_
 
+#include "lanelet2_map_validator/cli.hpp"
+
+#include <nlohmann/json.hpp>
+
 #include <string>
 
 namespace lanelet::autoware::validation
@@ -22,6 +26,7 @@ namespace lanelet::autoware::validation
 std::string get_validator_version();
 void insert_validator_info_to_map(
   std::string osm_file, std::string requirements, std::string requirements_version);
+void insert_validation_info_to_json(nlohmann::json & json_data, MetaConfig config);
 }  // namespace lanelet::autoware::validation
 
 #endif  // LANELET2_MAP_VALIDATOR__IO_HPP_

--- a/autoware_lanelet2_map_validator/src/main.cpp
+++ b/autoware_lanelet2_map_validator/src/main.cpp
@@ -114,6 +114,7 @@ int main(int argc, char * argv[])
       json_data.value("version", ""));
 
     if (!meta_config.output_file_path.empty()) {
+      lanelet::autoware::validation::insert_validation_info_to_json(json_data, meta_config);
       lanelet::autoware::validation::export_results(json_data, meta_config.output_file_path);
     }
   } else {


### PR DESCRIPTION
## Description

This PR adds a `validation_info` block to the output `lanelet2_validation_results.json` file to benefit external tools that they can get the information what kind of validation was done.

The validation_info block will look like this.
```json
"validation_info": {
    "map_requirements": {
        "filename": "common.json",
        "version": "1.0.2"
    },
    "target_map": "komatsu/lanelet2_map.osm",
    "validator": {
        "name": "autoware_lanelet2_map_validator",
        "version": "1.3.0"
    }
}
```

It adds the information of...
- Map file name and its parent directory
- File name of map_requirements
- Version of the map_requirements
- Name of this tool (= autoware_lanelet2_map_validator)
- Version of autoware_lanelet2_map_validator

## How was this PR tested?

Checked that usual usage has be done as intended.
Confirmed that colcon test passes.

## Notes for reviewers

None.

## Effects on system behavior

A new output `validation_info` will be appended to the lanelet2_validation_results.json.
