### PR TITLE
fix: fix name mistakes about mapping.intersection.virtual_traffic_light_line_order

### DIFF
--- a/autoware_lanelet2_map_validator/map_requirements/autoware_requirement_set.json
+++ b/autoware_lanelet2_map_validator/map_requirements/autoware_requirement_set.json
@@ -59,7 +59,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_2_0.json
@@ -16,7 +16,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_7_0.json
@@ -16,7 +16,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2025_3_0.json
@@ -16,7 +16,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/common.json
@@ -59,7 +59,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/delivery_robot-v2023_10_2.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/delivery_robot-v2023_10_2.json
@@ -16,7 +16,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.mapping.intersection.virtual_traffic_light_line_order",
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
           "prerequisites": [
             {
               "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
@@ -14,6 +14,14 @@
       "validators": [
         {
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+            }
+          ]
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
@@ -14,6 +14,14 @@
       "validators": [
         {
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+            }
+          ]
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
@@ -57,6 +57,14 @@
       "validators": [
         {
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+            }
+          ]
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/delivery_robot-v2023_10_2.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/delivery_robot-v2023_10_2.json
@@ -14,6 +14,14 @@
       "validators": [
         {
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Description

Fix name mistakes about mapping.intersection.virtual_traffic_light_line_order, and add mapping.intersection.virtual_traffic_light_line_order to archived verisons

## How was this PR tested?

Checked that normal use `ros2 run ...` works well

## Notes for reviewers

Excuse me for bypass merging this.

## Effects on system behavior

None.
