### PR TITLE
fix: do not count wrong polygon orientation as an issue

### DIFF
--- a/autoware_lanelet2_map_validator/docs/intersection/intersection_area_validity.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/intersection_area_validity.md
@@ -8,6 +8,8 @@ mapping.intersection.intersection_area_validity
 
 This validator check whether each `intersection_area` type polygon satisfies [`boost::geometry::is_valid`](https://www.boost.io/doc/libs/1_86_0/libs/geometry/doc/html/geometry/reference/algorithms/is_valid/is_valid_2_with_message.html).
 
+However, currently Autoware doesn't care about the polygon orientation so "wrong orientation" errors are ignored.
+
 The validator outputs the following issue with the corresponding ID of the primitive.
 
 | Issue Code                                | Message                                                                                 | Severity | Primitive | Description                                                                 | Approach                                                                                                                                                                                                                                                                       |

--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_validity.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_validity.cpp
@@ -26,6 +26,8 @@
 #include <map>
 #include <string>
 
+namespace bg = boost::geometry;
+
 namespace lanelet::autoware::validation
 {
 namespace
@@ -57,11 +59,11 @@ lanelet::validation::Issues IntersectionAreaValidityValidator::check_intersectio
 
     lanelet::BasicPolygon2d basic_polygon2d = lanelet::traits::to2D(polygon3d.basicPolygon());
 
-    std::string reason;
-    bool polygon_is_valid = boost::geometry::is_valid(basic_polygon2d, reason);
-    if (!polygon_is_valid) {
+    bg::validity_failure_type failure_type;
+    bool polygon_is_valid = bg::is_valid(basic_polygon2d, failure_type);
+    if (!polygon_is_valid && failure_type != bg::validity_failure_type::failure_wrong_orientation) {
       std::map<std::string, std::string> reason_map;
-      reason_map["boost_geometry_message"] = reason;
+      reason_map["boost_geometry_message"] = bg::validity_failure_type_message(failure_type);
       issues.emplace_back(
         construct_issue_from_code(issue_code(this->name(), 1), polygon3d.id(), reason_map));
     }

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_validity.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_validity.cpp
@@ -48,15 +48,7 @@ TEST_F(TestIntersectionAreaValidity, CheckWrongOrientation)  // NOLINT for gtest
   lanelet::autoware::validation::IntersectionAreaValidityValidator checker;
   const auto & issues = checker(*map_);
 
-  std::map<std::string, std::string> reason_map;
-  reason_map["boost_geometry_message"] = "Geometry has wrong orientation";
-  const auto expected_issue =
-    construct_issue_from_code(issue_code(test_target_, 1), 10803, reason_map);
-
-  EXPECT_EQ(issues.size(), 1);
-
-  const auto difference = compare_an_issue(expected_issue, issues[0]);
-  EXPECT_TRUE(difference.empty()) << difference;
+  EXPECT_EQ(issues.size(), 0);
 }
 
 TEST_F(TestIntersectionAreaValidity, CheckSelfIntersection)  // NOLINT for gtest


### PR DESCRIPTION
## Description

This PR fixes `mapping.intersection.intersection_area_validity` so that "wrong orientation" error of polygons will be ignored.
Hence, this PR does the following
- Do not create issues when the `is_valid` is false but is actually a "wrong orientation" issue.
- Change the test of "wrong orientation" map and check that no issues will be detected.
- Add about this change in the documentation.

## How was this PR tested?

- Check that "wrong orientation" related message do not appear when I `ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator` to any map.
- Check that `colcon test` passes.

## Notes for reviewers

None.

## Effects on system behavior

None.
