### PR TITLE
feat: enable stand alone execution by removing dependency on ament_index_cpp

### DIFF
--- a/autoware_lanelet2_map_validator/CMakeLists.txt
+++ b/autoware_lanelet2_map_validator/CMakeLists.txt
@@ -4,11 +4,35 @@ project(autoware_lanelet2_map_validator)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# Dependencies
 ament_auto_find_build_dependencies()
 find_package(fmt REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
+# Extract package version
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.xml" PACKAGE_XML_CONTENT)
+string(REGEX MATCH "<version>[^\n\r<]*</version>" VERSION_TAG "${PACKAGE_XML_CONTENT}")
+string(REGEX REPLACE ".*<version>([^\n\r<]*)</version>.*" "\\1" PACKAGE_VERSION "${VERSION_TAG}")
+
+set(PACKAGE_VERSION_STR "${PACKAGE_VERSION}")
+
+message(STATUS "Building version ${PACKAGE_VERSION}")
+
+# Default parameters to embed
+file(READ "config/params.yaml" EMBEDDED_YAML)
+file(READ "config/issues_info.json" EMBEDDED_JSON)
+
+set(DEFAULT_YAML "${EMBEDDED_YAML}")
+set(DEFAULT_JSON "${EMBEDDED_JSON}")
+
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/include/lanelet2_map_validator/embedded_defaults.hpp.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/lanelet2_map_validator/embedded_defaults.hpp"
+  @ONLY
+)
+
+# Source files
 file(GLOB_RECURSE autoware_lanelet2_map_validator_lib_src
   src/common/*.cpp
   src/validators/*.cpp
@@ -18,8 +42,11 @@ ament_auto_add_library(autoware_lanelet2_map_validator_lib SHARED
   ${autoware_lanelet2_map_validator_lib_src}
 )
 
+# NOTE: keep this order in target_include_directories or the build system
+# selects the wrong embedded_defaults.hpp
 target_include_directories(
   autoware_lanelet2_map_validator_lib PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/include
   src/include
 )
 

--- a/autoware_lanelet2_map_validator/src/common/io.cpp
+++ b/autoware_lanelet2_map_validator/src/common/io.cpp
@@ -15,8 +15,8 @@
 #include "lanelet2_map_validator/io.hpp"
 
 #include "lanelet2_map_validator/cli.hpp"
+#include "lanelet2_map_validator/embedded_defaults.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <nlohmann/json.hpp>
 #include <pugixml.hpp>
 
@@ -28,26 +28,7 @@ namespace lanelet::autoware::validation
 {
 std::string get_validator_version()
 {
-  std::string package_share_directory =
-    ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
-  std::filesystem::path package_xml =
-    std::filesystem::path(package_share_directory) / "package.xml";
-
-  if (!std::filesystem::exists(package_xml)) {
-    throw std::runtime_error("package.xml not found in " + package_share_directory);
-  }
-
-  pugi::xml_document doc;
-  if (!doc.load_file(package_xml.c_str())) {
-    throw std::runtime_error("Failed to parse package.xml!");
-  }
-
-  pugi::xml_node version_node = doc.child("package").child("version");
-  if (!version_node) {
-    throw std::runtime_error("No <version> tag found in package.xml!");
-  }
-
-  return version_node.text().as_string();
+  return package_version_str_;
 }
 
 void insert_validator_info_to_map(

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/config_store.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/config_store.hpp
@@ -15,6 +15,7 @@
 #ifndef LANELET2_MAP_VALIDATOR__CONFIG_STORE_HPP_
 #define LANELET2_MAP_VALIDATOR__CONFIG_STORE_HPP_
 
+#include "lanelet2_map_validator/embedded_defaults.hpp"
 #include "lanelet2_map_validator/utils.hpp"
 
 #include <nlohmann/json.hpp>
@@ -39,16 +40,25 @@ public:
     const std::string & params_yaml_file, const std::string & issues_info_json_file,
     const std::string & language)
   {
-    yaml_ = YAML::LoadFile(params_yaml_file);
-
-    std::ifstream json_ifs(issues_info_json_file);
-    if (!json_ifs.is_open()) {
-      throw std::runtime_error("Failed to open JSON file: " + issues_info_json_file);
+    if (params_yaml_file.empty()) {
+      yaml_ = YAML::Load(default_yaml_str_);
+    } else {
+      yaml_ = YAML::LoadFile(params_yaml_file);
     }
-    json_ifs >> json_;
+
+    if (issues_info_json_file.empty()) {
+      json_ = nlohmann::json::parse(default_json_str_);
+    } else {
+      std::ifstream json_ifs(issues_info_json_file);
+      if (!json_ifs.is_open()) {
+        throw std::runtime_error("Failed to open JSON file: " + issues_info_json_file);
+      }
+      json_ifs >> json_;
+    }
 
     language_ = language;
   }
+
   static const YAML::Node & parameters() { return yaml_; }
   static const nlohmann::json & issues_info() { return json_; }
   static const std::string & language() { return language_; }

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/embedded_defaults.hpp.in
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/embedded_defaults.hpp.in
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifndef LANELET2_MAP_VALIDATOR__EMBEDDED_DEFAULTS_HPP_
+#define LANELET2_MAP_VALIDATOR__EMBEDDED_DEFAULTS_HPP_
+
+namespace lanelet::autoware::validation {
+  inline constexpr char default_yaml_str_[] = R"YAML_DELIM(@DEFAULT_YAML@)YAML_DELIM";
+  inline constexpr char default_json_str_[] = R"JSON_DELIM(@DEFAULT_JSON@)JSON_DELIM";
+  inline constexpr char package_version_str_[] = "@PACKAGE_VERSION_STR@";
+}
+
+#endif  // LANELET2_MAP_VALIDATOR__EMBEDDED_DEFAULTS_HPP_

--- a/autoware_lanelet2_map_validator/src/main.cpp
+++ b/autoware_lanelet2_map_validator/src/main.cpp
@@ -19,7 +19,6 @@
 #include "lanelet2_map_validator/utils.hpp"
 #include "lanelet2_map_validator/validation.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
@@ -94,14 +93,10 @@ int main(int argc, char * argv[])
   }
 
   // Load parameters and issues_info files
-  std::string package_share_directory =
-    ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
-  std::string parameters_file = (!meta_config.parameters_file.empty())
-                                  ? meta_config.parameters_file
-                                  : package_share_directory + "/config/params.yaml";
-  std::string issues_info_file =
-    package_share_directory +
-    "/config/issues_info.json";  // We think issues_info should NOT be derived for now
+  std::string parameters_file =
+    (!meta_config.parameters_file.empty()) ? meta_config.parameters_file : "";
+  // Currently, an empty string means "use the config/issues_info.json"
+  std::string issues_info_file = "";
   lanelet::autoware::validation::ValidatorConfigStore::initialize(
     parameters_file, issues_info_file, meta_config.language);
 


### PR DESCRIPTION
## Description

autoware_lanelet2_map_validator cannot be executed alone without `source install/setup.bash` since it reads the data in the `install` directory.

This PR removes that process by hard coding the default `params.yaml`, `issues_info.json` and package version during the compilation.

Thanks to this, autoware_lanelet2_map_validator can be used only by its built executable (which should be `${WORKSPACE}/build/autoware_lanelet2_map_validator/autoware_lanelet2_map_validator`).

## How was this PR tested?

Tested that executable `build/autoware_lanelet2_map_validator/autoware_lanelet2_map_validator` can be executed without `source install/setup.bash`.

```
# starting from the Autoware workspace
./build/autoware_lanelet2_map_validator/autoware_lanelet2_map_validator \
-p mgrs \
-m ./lanelet2_map.osm \
-i ./install/autoware_lanelet2_map_validator/share/autoware_lanelet2_map_validator/map_requirements/ \
autoware_requirement_set.json -o ./
```

I also tested that giving `--parameters ./param.yaml` with different parameters (such as `iou_threshold: 0.80`) will lead to different results which tells external parameters are applicable too.

## Notes for reviewers

**Note that ament_index_cpp is only removed from the main executable, and keeps remained in the test executables.**

## Effects on system behavior

None.
