### PR TITLE
feat(intersection): added validator for Lanelet's turn direction and virtual (vm-03-02)

### DIFF
--- a/autoware_lanelet2_map_validator/config/issues_info.json
+++ b/autoware_lanelet2_map_validator/config/issues_info.json
@@ -239,6 +239,14 @@
       "ja": "turn_signal_distance よりも前に \"turn_direction\" タグを持つ lanelet があります。(前にある右左折 lanelet: {prev_ids})"
     }
   },
+  "Intersection.LaneletBorderType-001": {
+    "severity": "Error",
+    "primitive": "lanelet",
+    "message": {
+      "en": "The LeftBound and RightBound of lanelet with intersection_area tag must be either virtual or road_border type.",
+      "ja": "intersection_area タグを持つ lanelet の LeftBound と RightBound は virtual または road_border タイプである必要があります。"
+    }
+  },
   "TrafficLight.MissingRegulatoryElements-001": {
     "severity": "Error",
     "primitive": "linestring",

--- a/autoware_lanelet2_map_validator/docs/intersection/intersection_lanelet_border_type.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/intersection_lanelet_border_type.md
@@ -1,0 +1,22 @@
+# intersection_lanelet_border_type
+
+## Validator name
+
+mapping.intersection.lanelet_border_type
+
+## Feature
+
+Feature explanation here.
+
+| Issue Code | Message | Severity | Primitive | Description | Approach |
+| ---------- | ------- | -------- | --------- | ----------- | -------- |
+|            |         |          |           |             |          |
+
+## Parameters
+
+None.
+
+## Related source codes
+
+- intersection_lanelet_border_type.cpp
+- intersection_lanelet_border_type.hpp

--- a/autoware_lanelet2_map_validator/docs/intersection/intersection_lanelet_border_type.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/intersection_lanelet_border_type.md
@@ -6,11 +6,13 @@ mapping.intersection.lanelet_border_type
 
 ## Feature
 
-Feature explanation here.
+This validator checks whether lanelets that have an `intersection_area` tag have proper border types. Specifically, it validates that both the LeftBound and RightBound of such lanelets are either of type "virtual" or "road_border".
 
-| Issue Code | Message | Severity | Primitive | Description | Approach |
-| ---------- | ------- | -------- | --------- | ----------- | -------- |
-|            |         |          |           |             |          |
+The validator will output the following issues with the corresponding primitive ID.
+
+| Issue Code                         | Message                                                                                                                 | Severity | Primitive | Description                                                                                                                                        | Approach                                                                                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Intersection.VirtualBorderType-001 | The LeftBound and RightBound of this lanelet with intersection_area tag must be either "virtual" or "road_border" type. | Error    | Lanelet   | Lanelets with intersection_area tags must have their borders properly typed as either "virtual" or "road_border" for proper intersection handling. | Set the type attribute of the LeftBound and RightBound linestrings to either "virtual" or "road_border" depending on the nature of the boundary. |
 
 ## Parameters
 

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp
@@ -1,0 +1,38 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_
+#define AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_
+
+#include <lanelet2_validation/Validation.h>
+#include <lanelet2_validation/ValidatorFactory.h>
+
+namespace lanelet::autoware::validation
+{
+class IntersectionLaneletBorderTypeValidator : public lanelet::validation::MapValidator
+{
+public:
+  constexpr static const char * name()
+  {
+    return "mapping.intersection.lanelet_border_type";
+  }
+
+  lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
+
+private:
+  lanelet::validation::Issues check_intersection_lanelet_border_type(const lanelet::LaneletMap & map);
+};
+}  // namespace lanelet::autoware::validation
+
+#endif  // AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_
-#define AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_
+#ifndef LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__INTERSECTION_LANELET_BORDER_TYPE_HPP_
+#define LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__INTERSECTION_LANELET_BORDER_TYPE_HPP_
 
 #include <lanelet2_validation/Validation.h>
 #include <lanelet2_validation/ValidatorFactory.h>
@@ -23,16 +23,14 @@ namespace lanelet::autoware::validation
 class IntersectionLaneletBorderTypeValidator : public lanelet::validation::MapValidator
 {
 public:
-  constexpr static const char * name()
-  {
-    return "mapping.intersection.lanelet_border_type";
-  }
+  constexpr static const char * name() { return "mapping.intersection.lanelet_border_type"; }
 
   lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
 
 private:
-  lanelet::validation::Issues check_intersection_lanelet_border_type(const lanelet::LaneletMap & map);
+  lanelet::validation::Issues check_intersection_lanelet_border_type(
+    const lanelet::LaneletMap & map);
 };
 }  // namespace lanelet::autoware::validation
 
-#endif  // AUTOWARE_LANELET2_MAP_VALIDATOR__TEMPLATE__VALIDATOR_TEMPLATE_HPP_
+#endif  // LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__INTERSECTION_LANELET_BORDER_TYPE_HPP_

--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_lanelet_border_type.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_lanelet_border_type.cpp
@@ -18,6 +18,8 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <string>
+
 namespace lanelet::autoware::validation
 {
 namespace
@@ -25,7 +27,8 @@ namespace
 lanelet::validation::RegisterMapValidator<IntersectionLaneletBorderTypeValidator> reg;
 }
 
-lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::operator()(const lanelet::LaneletMap & map)
+lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::operator()(
+  const lanelet::LaneletMap & map)
 {
   lanelet::validation::Issues issues;
 
@@ -34,28 +37,26 @@ lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::operator()(c
   return issues;
 }
 
-lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::check_intersection_lanelet_border_type(const lanelet::LaneletMap & map)
+lanelet::validation::Issues
+IntersectionLaneletBorderTypeValidator::check_intersection_lanelet_border_type(
+  const lanelet::LaneletMap & map)
 {
   lanelet::validation::Issues issues;
+
   for (const auto & lanelet : map.laneletLayer) {
     if (lanelet.hasAttribute("intersection_area")) {
-      const auto left_bound = lanelet.leftBound();
-      if (left_bound.hasAttribute(lanelet::AttributeName::Type)) {
-        const std::string left_type = left_bound.attribute(lanelet::AttributeName::Type).value();
-        if (left_type != "virtual" && left_type != "road_border") {
-          issues.emplace_back(
-            construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
-          continue; // skip right bound check if left bound is already invalid
-        }
-      } 
-      const auto right_bound = lanelet.rightBound();
-      if (right_bound.hasAttribute(lanelet::AttributeName::Type)) {
-        const std::string right_type = right_bound.attribute(lanelet::AttributeName::Type).value();
-        if (right_type != "virtual" && right_type != "road_border") {
-          issues.emplace_back(
-            construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
-        }
-      } 
+      const std::string left_type =
+        lanelet.leftBound().attributeOr(lanelet::AttributeName::Type, "");
+      if (left_type != "virtual" && left_type != "road_border") {
+        issues.emplace_back(construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
+        continue;  // skip right bound check if left bound is already invalid
+      }
+
+      const std::string right_type =
+        lanelet.rightBound().attributeOr(lanelet::AttributeName::Type, "");
+      if (right_type != "virtual" && right_type != "road_border") {
+        issues.emplace_back(construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
+      }
     }
   }
 

--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_lanelet_border_type.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_lanelet_border_type.cpp
@@ -1,0 +1,64 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp"
+
+#include "lanelet2_map_validator/utils.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+
+namespace lanelet::autoware::validation
+{
+namespace
+{
+lanelet::validation::RegisterMapValidator<IntersectionLaneletBorderTypeValidator> reg;
+}
+
+lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::operator()(const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::autoware::validation::appendIssues(issues, check_intersection_lanelet_border_type(map));
+
+  return issues;
+}
+
+lanelet::validation::Issues IntersectionLaneletBorderTypeValidator::check_intersection_lanelet_border_type(const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+  for (const auto & lanelet : map.laneletLayer) {
+    if (lanelet.hasAttribute("intersection_area")) {
+      const auto left_bound = lanelet.leftBound();
+      if (left_bound.hasAttribute(lanelet::AttributeName::Type)) {
+        const std::string left_type = left_bound.attribute(lanelet::AttributeName::Type).value();
+        if (left_type != "virtual" && left_type != "road_border") {
+          issues.emplace_back(
+            construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
+          continue; // skip right bound check if left bound is already invalid
+        }
+      } 
+      const auto right_bound = lanelet.rightBound();
+      if (right_bound.hasAttribute(lanelet::AttributeName::Type)) {
+        const std::string right_type = right_bound.attribute(lanelet::AttributeName::Type).value();
+        if (right_type != "virtual" && right_type != "road_border") {
+          issues.emplace_back(
+            construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
+        }
+      } 
+    }
+  }
+
+  return issues;
+}
+}  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/test/data/map/intersection/intersection_lanelet_invalid_border_type.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/intersection/intersection_lanelet_invalid_border_type.osm
@@ -1,0 +1,7831 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="56" validation_version=""/>
+  <node id="285" lat="35.90327302784" lon="139.9336616108">
+    <tag k="local_x" v="3774.4814"/>
+    <tag k="local_y" v="73745.2383"/>
+    <tag k="ele" v="19.267"/>
+  </node>
+  <node id="287" lat="35.90324402805" lon="139.93364250018">
+    <tag k="local_x" v="3772.7217"/>
+    <tag k="local_y" v="73742.0405"/>
+    <tag k="ele" v="19.273"/>
+  </node>
+  <node id="288" lat="35.90323819449" lon="139.93364041649">
+    <tag k="local_x" v="3772.5266"/>
+    <tag k="local_y" v="73741.3955"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="290" lat="35.9032057502" lon="139.93363708304">
+    <tag k="local_x" v="3772.1865"/>
+    <tag k="local_y" v="73737.8001"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="343" lat="35.90325133347" lon="139.93344963934">
+    <tag k="local_x" v="3755.3263"/>
+    <tag k="local_y" v="73743.0408"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="345" lat="35.90327994506" lon="139.93346888918">
+    <tag k="local_x" v="3757.0981"/>
+    <tag k="local_y" v="73746.1954"/>
+    <tag k="ele" v="19.23"/>
+  </node>
+  <node id="346" lat="35.90328672265" lon="139.93347138904">
+    <tag k="local_x" v="3757.3319"/>
+    <tag k="local_y" v="73746.9447"/>
+    <tag k="ele" v="19.225"/>
+  </node>
+  <node id="348" lat="35.90331916726" lon="139.93347486093">
+    <tag k="local_x" v="3757.6845"/>
+    <tag k="local_y" v="73750.54"/>
+    <tag k="ele" v="19.202"/>
+  </node>
+  <node id="360" lat="35.90319177783" lon="139.93353394455">
+    <tag k="local_x" v="3762.8621"/>
+    <tag k="local_y" v="73736.3519"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="361" lat="35.90319383421" lon="139.93352561156">
+    <tag k="local_x" v="3762.1126"/>
+    <tag k="local_y" v="73736.5882"/>
+    <tag k="ele" v="19.272"/>
+  </node>
+  <node id="363" lat="35.9031969451" lon="139.93348547233">
+    <tag k="local_x" v="3758.4941"/>
+    <tag k="local_y" v="73736.9728"/>
+    <tag k="ele" v="19.263"/>
+  </node>
+  <node id="397" lat="35.90317608354" lon="139.93356897239">
+    <tag k="local_x" v="3766.0041"/>
+    <tag k="local_y" v="73734.5766"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="420" lat="35.90334850041" lon="139.93354266698">
+    <tag k="local_x" v="3763.839"/>
+    <tag k="local_y" v="73753.7268"/>
+    <tag k="ele" v="19.21"/>
+  </node>
+  <node id="422" lat="35.90333302799" lon="139.93357841663">
+    <tag k="local_x" v="3767.0464"/>
+    <tag k="local_y" v="73751.9754"/>
+    <tag k="ele" v="19.223"/>
+  </node>
+  <node id="423" lat="35.90333113903" lon="139.93358580547">
+    <tag k="local_x" v="3767.7109"/>
+    <tag k="local_y" v="73751.7586"/>
+    <tag k="ele" v="19.226"/>
+  </node>
+  <node id="425" lat="35.90332841683" lon="139.93362555503">
+    <tag k="local_x" v="3771.2947"/>
+    <tag k="local_y" v="73751.4175"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="1095" lat="35.90306125027" lon="139.93309452792">
+    <tag k="local_x" v="3723.0499"/>
+    <tag k="local_y" v="73722.3069"/>
+    <tag k="ele" v="19.364"/>
+  </node>
+  <node id="1096" lat="35.90312502821" lon="139.93324083284">
+    <tag k="type" v="end"/>
+    <tag k="local_x" v="3736.3301"/>
+    <tag k="local_y" v="73729.2369"/>
+    <tag k="ele" v="19.397"/>
+  </node>
+  <node id="1097" lat="35.90307533416" lon="139.93312635919">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3725.9395"/>
+    <tag k="local_y" v="73723.8377"/>
+    <tag k="ele" v="19.402"/>
+  </node>
+  <node id="1098" lat="35.90316758414" lon="139.9333384171">
+    <tag k="local_x" v="3745.1879"/>
+    <tag k="local_y" v="73733.861"/>
+    <tag k="ele" v="19.374"/>
+  </node>
+  <node id="1099" lat="35.90313037417" lon="139.9332537893">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3737.5058"/>
+    <tag k="local_y" v="73729.8171"/>
+    <tag k="ele" v="19.389"/>
+  </node>
+  <node id="1100" lat="35.90336541715" lon="139.93379219407">
+    <tag k="type" v="end"/>
+    <tag k="local_x" v="3786.3774"/>
+    <tag k="local_y" v="73755.3574"/>
+    <tag k="ele" v="19.398"/>
+  </node>
+  <node id="1101" lat="35.90334438898" lon="139.93374394464">
+    <tag k="local_x" v="3781.9978"/>
+    <tag k="local_y" v="73753.0725"/>
+    <tag k="ele" v="19.378"/>
+  </node>
+  <node id="1102" lat="35.90340808418" lon="139.93389005557">
+    <tag k="type" v="end"/>
+    <tag k="local_x" v="3795.2603"/>
+    <tag k="local_y" v="73759.9936"/>
+    <tag k="ele" v="19.441"/>
+  </node>
+  <node id="1103" lat="35.90338686161" lon="139.93384133331">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3790.8378"/>
+    <tag k="local_y" v="73757.6876"/>
+    <tag k="ele" v="19.421"/>
+  </node>
+  <node id="1104" lat="35.9034506949" lon="139.93398777831">
+    <tag k="type" v="end"/>
+    <tag k="local_x" v="3804.1306"/>
+    <tag k="local_y" v="73764.6237"/>
+    <tag k="ele" v="19.414"/>
+  </node>
+  <node id="1105" lat="35.90342950016" lon="139.93393913873">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3799.7156"/>
+    <tag k="local_y" v="73762.3207"/>
+    <tag k="ele" v="19.435"/>
+  </node>
+  <node id="1106" lat="35.90349316733" lon="139.93408516613">
+    <tag k="local_x" v="3812.9705"/>
+    <tag k="local_y" v="73769.2388"/>
+    <tag k="ele" v="19.375"/>
+  </node>
+  <node id="1107" lat="35.90347208378" lon="139.93403686078">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3808.5858"/>
+    <tag k="local_y" v="73766.9478"/>
+    <tag k="ele" v="19.408"/>
+  </node>
+  <node id="1567" lat="35.90298648752" lon="139.93285367065">
+    <tag k="local_x" v="3701.2237"/>
+    <tag k="local_y" v="73714.2517"/>
+    <tag k="ele" v="19.234"/>
+  </node>
+  <node id="1568" lat="35.90296047723" lon="139.93287088325">
+    <tag k="local_x" v="3702.7455"/>
+    <tag k="local_y" v="73711.3497"/>
+    <tag k="ele" v="19.257"/>
+  </node>
+  <node id="1569" lat="35.90289938975" lon="139.93291130541">
+    <tag k="local_x" v="3706.3193"/>
+    <tag k="local_y" v="73704.5341"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="1571" lat="35.90302646559" lon="139.93282721714">
+    <tag k="local_x" v="3698.8849"/>
+    <tag k="local_y" v="73718.7121"/>
+    <tag k="ele" v="19.223"/>
+  </node>
+  <node id="1617" lat="35.90307098759" lon="139.93364417126">
+    <tag k="local_x" v="3772.663"/>
+    <tag k="local_y" v="73722.8454"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="1618" lat="35.90301841927" lon="139.93367866982">
+    <tag k="local_x" v="3775.7126"/>
+    <tag k="local_y" v="73716.9806"/>
+    <tag k="ele" v="19.389"/>
+  </node>
+  <node id="1619" lat="35.90296583839" lon="139.93371317625">
+    <tag k="local_x" v="3778.7629"/>
+    <tag k="local_y" v="73711.1144"/>
+    <tag k="ele" v="19.428"/>
+  </node>
+  <node id="1620" lat="35.90295750025" lon="139.93371870239">
+    <tag k="local_x" v="3779.2515"/>
+    <tag k="local_y" v="73710.1841"/>
+    <tag k="ele" v="19.433"/>
+  </node>
+  <node id="1621" lat="35.90309585886" lon="139.93370243846">
+    <tag k="local_x" v="3777.9513"/>
+    <tag k="local_y" v="73725.5467"/>
+    <tag k="ele" v="19.364"/>
+  </node>
+  <node id="1622" lat="35.90304326465" lon="139.93373696836">
+    <tag k="local_x" v="3781.0037"/>
+    <tag k="local_y" v="73719.679"/>
+    <tag k="ele" v="19.39"/>
+  </node>
+  <node id="1623" lat="35.90299065699" lon="139.93377150616">
+    <tag k="local_x" v="3784.0568"/>
+    <tag k="local_y" v="73713.8098"/>
+    <tag k="ele" v="19.42"/>
+  </node>
+  <node id="1624" lat="35.90298345583" lon="139.9337762336">
+    <tag k="local_x" v="3784.4747"/>
+    <tag k="local_y" v="73713.0064"/>
+    <tag k="ele" v="19.421"/>
+  </node>
+  <node id="1708" lat="35.90305238397" lon="139.93314359935">
+    <tag k="local_x" v="3727.4675"/>
+    <tag k="local_y" v="73721.2751"/>
+    <tag k="ele" v="19.321"/>
+  </node>
+  <node id="1709" lat="35.90304366681" lon="139.93312391643">
+    <tag k="local_x" v="3725.6807"/>
+    <tag k="local_y" v="73720.3276"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="1710" lat="35.90299648341" lon="139.93301582529">
+    <tag k="local_x" v="3715.8691"/>
+    <tag k="local_y" v="73715.2006"/>
+    <tag k="ele" v="19.2909"/>
+  </node>
+  <node id="1711" lat="35.90298891709" lon="139.93299852825">
+    <tag k="local_x" v="3714.299"/>
+    <tag k="local_y" v="73714.3784"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="1712" lat="35.90298633383" lon="139.93299261121">
+    <tag k="local_x" v="3713.7619"/>
+    <tag k="local_y" v="73714.0977"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="1714" lat="35.90309541703" lon="139.93324241706">
+    <tag k="local_x" v="3736.4372"/>
+    <tag k="local_y" v="73725.9509"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="1717" lat="35.90303577052" lon="139.93296720872">
+    <tag k="local_x" v="3711.5294"/>
+    <tag k="local_y" v="73719.6062"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="1718" lat="35.90304351967" lon="139.93298478811">
+    <tag k="local_x" v="3713.1252"/>
+    <tag k="local_y" v="73720.4484"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="1719" lat="35.90309044922" lon="139.93309271759">
+    <tag k="local_x" v="3722.9219"/>
+    <tag k="local_y" v="73725.5474"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="1720" lat="35.90311791696" lon="139.93315541662">
+    <tag k="local_x" v="3728.6133"/>
+    <tag k="local_y" v="73728.5323"/>
+    <tag k="ele" v="19.308"/>
+  </node>
+  <node id="1721" lat="35.90312088971" lon="139.9331622504">
+    <tag k="local_x" v="3729.2336"/>
+    <tag k="local_y" v="73728.8553"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="1723" lat="35.90314236196" lon="139.93321144435">
+    <tag k="local_x" v="3733.699"/>
+    <tag k="local_y" v="73731.1885"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="1724" lat="35.90316383395" lon="139.93326061063">
+    <tag k="local_x" v="3738.1619"/>
+    <tag k="local_y" v="73733.5217"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="1725" lat="35.90316683399" lon="139.93326747176">
+    <tag k="local_x" v="3738.7847"/>
+    <tag k="local_y" v="73733.8477"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="1726" lat="35.90340566258" lon="139.93395484148">
+    <tag k="local_x" v="3801.1038"/>
+    <tag k="local_y" v="73759.6612"/>
+    <tag k="ele" v="19.435"/>
+  </node>
+  <node id="1727" lat="35.90338424569" lon="139.93390575613">
+    <tag k="local_x" v="3796.6483"/>
+    <tag k="local_y" v="73757.334"/>
+    <tag k="ele" v="19.441"/>
+  </node>
+  <node id="1728" lat="35.90336302405" lon="139.93385703497">
+    <tag k="local_x" v="3792.2259"/>
+    <tag k="local_y" v="73755.0281"/>
+    <tag k="ele" v="19.421"/>
+  </node>
+  <node id="1729" lat="35.90334158052" lon="139.93380789905">
+    <tag k="local_x" v="3787.7658"/>
+    <tag k="local_y" v="73752.698"/>
+    <tag k="ele" v="19.398"/>
+  </node>
+  <node id="1730" lat="35.90348869128" lon="139.93414531444">
+    <tag k="local_x" v="3818.393"/>
+    <tag k="local_y" v="73768.6831"/>
+    <tag k="ele" v="19.351"/>
+  </node>
+  <node id="1731" lat="35.90346933064" lon="139.93410086884">
+    <tag k="local_x" v="3814.3587"/>
+    <tag k="local_y" v="73766.5794"/>
+    <tag k="ele" v="19.375"/>
+  </node>
+  <node id="1732" lat="35.90344824712" lon="139.93405256571">
+    <tag k="local_x" v="3809.9742"/>
+    <tag k="local_y" v="73764.2884"/>
+    <tag k="ele" v="19.408"/>
+  </node>
+  <node id="1733" lat="35.90342685455" lon="139.93400347333">
+    <tag k="local_x" v="3805.5181"/>
+    <tag k="local_y" v="73761.9639"/>
+    <tag k="ele" v="19.414"/>
+  </node>
+  <node id="1735" lat="35.90347094505" lon="139.93396475019">
+    <tag k="local_x" v="3802.077"/>
+    <tag k="local_y" v="73766.8925"/>
+    <tag k="ele" v="19.353"/>
+  </node>
+  <node id="1736" lat="35.9034983059" lon="139.93402744461">
+    <tag k="local_x" v="3807.7678"/>
+    <tag k="local_y" v="73769.8656"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="1737" lat="35.90352566673" lon="139.93409013907">
+    <tag k="local_x" v="3813.4586"/>
+    <tag k="local_y" v="73772.8387"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="1738" lat="35.90355302818" lon="139.93415280586">
+    <tag k="local_x" v="3819.1469"/>
+    <tag k="local_y" v="73775.8119"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="1739" lat="35.90355541744" lon="139.93415830561">
+    <tag k="local_x" v="3819.6461"/>
+    <tag k="local_y" v="73776.0715"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="1740" lat="35.90340708363" lon="139.93381838866">
+    <tag k="local_x" v="3788.7917"/>
+    <tag k="local_y" v="73759.9532"/>
+    <tag k="ele" v="19.341"/>
+  </node>
+  <node id="1741" lat="35.90343752858" lon="139.93388816687">
+    <tag k="local_x" v="3795.1255"/>
+    <tag k="local_y" v="73763.2614"/>
+    <tag k="ele" v="19.369"/>
+  </node>
+  <node id="1742" lat="35.90346797234" lon="139.93395791634">
+    <tag k="local_x" v="3801.4567"/>
+    <tag k="local_y" v="73766.5695"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="1780" lat="35.90350808603" lon="139.93418974408">
+    <tag k="local_x" v="3822.4259"/>
+    <tag k="local_y" v="73770.7906"/>
+    <tag k="ele" v="19.383"/>
+  </node>
+  <node id="1786" lat="35.90298505564" lon="139.93298969406">
+    <tag k="local_x" v="3713.4971"/>
+    <tag k="local_y" v="73713.9588"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="1787" lat="35.90292655646" lon="139.93296822166">
+    <tag k="local_x" v="3711.4885"/>
+    <tag k="local_y" v="73707.4913"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="1788" lat="35.90292485417" lon="139.93296952439">
+    <tag k="local_x" v="3711.604"/>
+    <tag k="local_y" v="73707.3012"/>
+    <tag k="ele" v="19.359"/>
+  </node>
+  <node id="1794" lat="35.90305163976" lon="139.93288594428">
+    <tag k="local_x" v="3704.2151"/>
+    <tag k="local_y" v="73721.4465"/>
+    <tag k="ele" v="19.232"/>
+  </node>
+  <node id="1795" lat="35.90305008354" lon="139.93288694476">
+    <tag k="local_x" v="3704.3035"/>
+    <tag k="local_y" v="73721.2729"/>
+    <tag k="ele" v="19.234"/>
+  </node>
+  <node id="1796" lat="35.90303205601" lon="139.93295877813">
+    <tag k="local_x" v="3710.7641"/>
+    <tag k="local_y" v="73719.2025"/>
+    <tag k="ele" v="19.299"/>
+  </node>
+  <node id="1797" lat="35.90303316755" lon="139.93296130524">
+    <tag k="local_x" v="3710.9935"/>
+    <tag k="local_y" v="73719.3233"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="1884" lat="35.90319233426" lon="139.93332588893">
+    <tag k="local_x" v="3744.0873"/>
+    <tag k="local_y" v="73736.6186"/>
+    <tag k="ele" v="19.3"/>
+  </node>
+  <node id="1885" lat="35.90322491716" lon="139.93340125738">
+    <tag k="local_x" v="3750.9282"/>
+    <tag k="local_y" v="73740.1584"/>
+    <tag k="ele" v="19.2908"/>
+  </node>
+  <node id="1886" lat="35.90324225046" lon="139.93344022249">
+    <tag k="local_x" v="3754.4655"/>
+    <tag k="local_y" v="73742.0426"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="1888" lat="35.90332054959" lon="139.93375964302">
+    <tag k="local_x" v="3783.3856"/>
+    <tag k="local_y" v="73750.4128"/>
+    <tag k="ele" v="19.378"/>
+  </node>
+  <node id="1889" lat="35.90330127284" lon="139.93371542144">
+    <tag k="local_x" v="3779.3716"/>
+    <tag k="local_y" v="73748.3182"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="1890" lat="35.90328199517" lon="139.93367119989">
+    <tag k="local_x" v="3775.3576"/>
+    <tag k="local_y" v="73746.2235"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="1891" lat="35.90316830636" lon="139.93358030536">
+    <tag k="local_x" v="3767.0174"/>
+    <tag k="local_y" v="73733.7028"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="1892" lat="35.90312336856" lon="139.93360979596">
+    <tag k="local_x" v="3769.6243"/>
+    <tag k="local_y" v="73728.6893"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="1893" lat="35.90307619619" lon="139.93364075264">
+    <tag k="local_x" v="3772.3608"/>
+    <tag k="local_y" v="73723.4265"/>
+    <tag k="ele" v="19.361"/>
+  </node>
+  <node id="1895" lat="35.90344897289" lon="139.93347069455">
+    <tag k="local_x" v="3757.4657"/>
+    <tag k="local_y" v="73764.942"/>
+    <tag k="ele" v="19.163"/>
+  </node>
+  <node id="1896" lat="35.9034017507" lon="139.93350172192">
+    <tag k="local_x" v="3760.2085"/>
+    <tag k="local_y" v="73759.6736"/>
+    <tag k="ele" v="19.209"/>
+  </node>
+  <node id="1897" lat="35.90335627849" lon="139.9335316387">
+    <tag k="local_x" v="3762.8532"/>
+    <tag k="local_y" v="73754.6004"/>
+    <tag k="ele" v="19.225"/>
+  </node>
+  <node id="1898" lat="35.90326836177" lon="139.93355191689">
+    <tag k="local_x" v="3764.5767"/>
+    <tag k="local_y" v="73744.8288"/>
+    <tag k="ele" v="19.358"/>
+  </node>
+  <node id="1899" lat="35.90326238946" lon="139.93355583335">
+    <tag k="local_x" v="3764.9229"/>
+    <tag k="local_y" v="73744.1625"/>
+    <tag k="ele" v="19.367"/>
+  </node>
+  <node id="1900" lat="35.9032561117" lon="139.93355997221">
+    <tag k="local_x" v="3765.2888"/>
+    <tag k="local_y" v="73743.4621"/>
+    <tag k="ele" v="19.37"/>
+  </node>
+  <node id="1901" lat="35.90326569456" lon="139.93356344394">
+    <tag k="local_x" v="3765.6137"/>
+    <tag k="local_y" v="73744.5216"/>
+    <tag k="ele" v="19.362"/>
+  </node>
+  <node id="1903" lat="35.90325908421" lon="139.93354830588">
+    <tag k="local_x" v="3764.2396"/>
+    <tag k="local_y" v="73743.8033"/>
+    <tag k="ele" v="19.372"/>
+  </node>
+  <node id="1932" lat="35.90298180646" lon="139.93289402812">
+    <tag k="local_x" v="3704.86"/>
+    <tag k="local_y" v="73713.6927"/>
+    <tag k="ele" v="19.329"/>
+  </node>
+  <node id="1933" lat="35.90297558387" lon="139.93289808317">
+    <tag k="local_x" v="3705.2184"/>
+    <tag k="local_y" v="73712.9985"/>
+    <tag k="ele" v="19.334"/>
+  </node>
+  <node id="1934" lat="35.90296944538" lon="139.93290216701">
+    <tag k="local_x" v="3705.5795"/>
+    <tag k="local_y" v="73712.3136"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="1935" lat="35.9029789172" lon="139.93290572213">
+    <tag k="local_x" v="3705.9118"/>
+    <tag k="local_y" v="73713.3607"/>
+    <tag k="ele" v="19.329"/>
+  </node>
+  <node id="1970" lat="35.9035492506" lon="139.9334043051">
+    <tag k="local_x" v="3751.596"/>
+    <tag k="local_y" v="73776.1301"/>
+    <tag k="ele" v="19.119"/>
+  </node>
+  <node id="1971" lat="35.90350661139" lon="139.93343252732">
+    <tag k="local_x" v="3754.0912"/>
+    <tag k="local_y" v="73771.3728"/>
+    <tag k="ele" v="19.127"/>
+  </node>
+  <node id="1972" lat="35.90345416683" lon="139.9334672495">
+    <tag k="local_x" v="3757.1611"/>
+    <tag k="local_y" v="73765.5215"/>
+    <tag k="ele" v="19.16"/>
+  </node>
+  <node id="1975" lat="35.90352486192" lon="139.93334577743">
+    <tag k="local_x" v="3746.2848"/>
+    <tag k="local_y" v="73773.4826"/>
+    <tag k="ele" v="19.092"/>
+  </node>
+  <node id="1976" lat="35.90348163933" lon="139.93337419478">
+    <tag k="local_x" v="3748.7969"/>
+    <tag k="local_y" v="73768.6604"/>
+    <tag k="ele" v="19.126"/>
+  </node>
+  <node id="1977" lat="35.90342872262" lon="139.93340894437">
+    <tag k="local_x" v="3751.8687"/>
+    <tag k="local_y" v="73762.7567"/>
+    <tag k="ele" v="19.159"/>
+  </node>
+  <node id="1978" lat="35.90342352843" lon="139.93341236062">
+    <tag k="local_x" v="3752.1707"/>
+    <tag k="local_y" v="73762.1772"/>
+    <tag k="ele" v="19.162"/>
+  </node>
+  <node id="1991" lat="35.9033761948" lon="139.93344352803">
+    <tag k="local_x" v="3754.926"/>
+    <tag k="local_y" v="73756.8963"/>
+    <tag k="ele" v="19.199"/>
+  </node>
+  <node id="1992" lat="35.9033309452" lon="139.93347333325">
+    <tag k="local_x" v="3757.5609"/>
+    <tag k="local_y" v="73751.8479"/>
+    <tag k="ele" v="19.216"/>
+  </node>
+  <node id="1993" lat="35.90332883346" lon="139.93347472236">
+    <tag k="local_x" v="3757.6837"/>
+    <tag k="local_y" v="73751.6123"/>
+    <tag k="ele" v="19.218"/>
+  </node>
+  <node id="1994" lat="35.90319650052" lon="139.93347388843">
+    <tag k="local_x" v="3757.4482"/>
+    <tag k="local_y" v="73736.9349"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="1995" lat="35.90319541743" lon="139.93347141633">
+    <tag k="local_x" v="3757.2238"/>
+    <tag k="local_y" v="73736.8172"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="1996" lat="35.90317767853" lon="139.93343114244">
+    <tag k="local_x" v="3753.5679"/>
+    <tag k="local_y" v="73734.8893"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="1997" lat="35.90314536151" lon="139.93335677774">
+    <tag k="local_x" v="3746.8179"/>
+    <tag k="local_y" v="73731.378"/>
+    <tag k="ele" v="19.311"/>
+  </node>
+  <node id="1998" lat="35.90310714874" lon="139.93326907397">
+    <tag k="local_x" v="3738.857"/>
+    <tag k="local_y" v="73727.2259"/>
+    <tag k="ele" v="19.316"/>
+  </node>
+  <node id="2000" lat="35.90332827859" lon="139.93363780501">
+    <tag k="local_x" v="3772.4"/>
+    <tag k="local_y" v="73751.3901"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="2001" lat="35.90332919481" lon="139.93363986159">
+    <tag k="local_x" v="3772.5867"/>
+    <tag k="local_y" v="73751.4897"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="2002" lat="35.90335355606" lon="139.93369572231">
+    <tag k="local_x" v="3777.6572"/>
+    <tag k="local_y" v="73754.1368"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="2003" lat="35.9033788335" lon="139.93375363855">
+    <tag k="local_x" v="3782.9143"/>
+    <tag k="local_y" v="73756.8835"/>
+    <tag k="ele" v="19.327"/>
+  </node>
+  <node id="2004" lat="35.90340411116" lon="139.93381158363">
+    <tag k="local_x" v="3788.174"/>
+    <tag k="local_y" v="73759.6302"/>
+    <tag k="ele" v="19.343"/>
+  </node>
+  <node id="2006" lat="35.90319577788" lon="139.93363686113">
+    <tag k="local_x" v="3772.1544"/>
+    <tag k="local_y" v="73736.6942"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="2007" lat="35.90319325003" lon="139.93363849961">
+    <tag k="local_x" v="3772.2992"/>
+    <tag k="local_y" v="73736.4122"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="2008" lat="35.90314819312" lon="139.93366808043">
+    <tag k="local_x" v="3774.9141"/>
+    <tag k="local_y" v="73731.3854"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="2009" lat="35.90310060584" lon="139.9336993219">
+    <tag k="local_x" v="3777.6758"/>
+    <tag k="local_y" v="73726.0763"/>
+    <tag k="ele" v="19.363"/>
+  </node>
+  <node id="2048" lat="35.90303396753" lon="139.93282225287">
+    <tag k="local_x" v="3698.446"/>
+    <tag k="local_y" v="73719.5491"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="2049" lat="35.90303159953" lon="139.93282381941">
+    <tag k="local_x" v="3698.5845"/>
+    <tag k="local_y" v="73719.2849"/>
+    <tag k="ele" v="19.22"/>
+  </node>
+  <node id="2053" lat="35.90306000039" lon="139.93288041664">
+    <tag k="local_x" v="3703.7264"/>
+    <tag k="local_y" v="73722.3793"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="2054" lat="35.90305683369" lon="139.93288250032">
+    <tag k="local_x" v="3703.9106"/>
+    <tag k="local_y" v="73722.026"/>
+    <tag k="ele" v="19.225"/>
+  </node>
+  <node id="2165" lat="35.90291191703" lon="139.93294033288">
+    <tag k="local_x" v="3708.954"/>
+    <tag k="local_y" v="73705.895"/>
+    <tag k="ele" v="19.359"/>
+  </node>
+  <node id="2173" lat="35.90304694502" lon="139.93285141617">
+    <tag k="local_x" v="3701.0935"/>
+    <tag k="local_y" v="73720.9598"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="2174" lat="35.90342694504" lon="139.93344775048">
+    <tag k="local_x" v="3755.3685"/>
+    <tag k="local_y" v="73762.5213"/>
+    <tag k="ele" v="19.239"/>
+  </node>
+  <node id="2175" lat="35.90338527816" lon="139.93347511076">
+    <tag k="local_x" v="3757.7871"/>
+    <tag k="local_y" v="73757.8727"/>
+    <tag k="ele" v="19.267"/>
+  </node>
+  <node id="2176" lat="35.90334361152" lon="139.93350249983">
+    <tag k="local_x" v="3760.2083"/>
+    <tag k="local_y" v="73753.2241"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="2177" lat="35.90318077833" lon="139.93360941688">
+    <tag k="local_x" v="3769.6596"/>
+    <tag k="local_y" v="73735.0575"/>
+    <tag k="ele" v="19.373"/>
+  </node>
+  <node id="2178" lat="35.90313333651" lon="139.93364058996">
+    <tag k="local_x" v="3772.4153"/>
+    <tag k="local_y" v="73729.7646"/>
+    <tag k="ele" v="19.398"/>
+  </node>
+  <node id="2179" lat="35.90308589467" lon="139.93367176188">
+    <tag k="local_x" v="3775.1709"/>
+    <tag k="local_y" v="73724.4717"/>
+    <tag k="ele" v="19.422"/>
+  </node>
+  <node id="2180" lat="35.90305811832" lon="139.93369001409">
+    <tag k="local_x" v="3776.7844"/>
+    <tag k="local_y" v="73721.3728"/>
+    <tag k="ele" v="19.438"/>
+  </node>
+  <node id="2181" lat="35.9030160168" lon="139.93371767692">
+    <tag k="local_x" v="3779.2298"/>
+    <tag k="local_y" v="73716.6757"/>
+    <tag k="ele" v="19.466"/>
+  </node>
+  <node id="2182" lat="35.90297019462" lon="139.93374778539">
+    <tag k="local_x" v="3781.8914"/>
+    <tag k="local_y" v="73711.5635"/>
+    <tag k="ele" v="19.49"/>
+  </node>
+  <node id="2193" lat="35.90301982398" lon="139.93300010907">
+    <tag k="local_x" v="3714.4791"/>
+    <tag k="local_y" v="73717.805"/>
+    <tag k="ele" v="19.356"/>
+  </node>
+  <node id="2194" lat="35.90300994522" lon="139.93297683372">
+    <tag k="local_x" v="3712.3667"/>
+    <tag k="local_y" v="73716.7322"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="2195" lat="35.90321877841" lon="139.9334558606">
+    <tag k="local_x" v="3755.8483"/>
+    <tag k="local_y" v="73739.4237"/>
+    <tag k="ele" v="19.341"/>
+  </node>
+  <node id="2196" lat="35.9032016162" lon="139.93341565321">
+    <tag k="local_x" v="3752.1991"/>
+    <tag k="local_y" v="73737.5597"/>
+    <tag k="ele" v="19.3542"/>
+  </node>
+  <node id="2199" lat="35.90332511131" lon="139.93369972195">
+    <tag k="local_x" v="3777.9837"/>
+    <tag k="local_y" v="73750.9778"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="2200" lat="35.90330583363" lon="139.93365550039">
+    <tag k="local_x" v="3773.9697"/>
+    <tag k="local_y" v="73748.8831"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="2201" lat="35.9035319172" lon="139.93417402817">
+    <tag k="local_x" v="3821.0365"/>
+    <tag k="local_y" v="73773.4494"/>
+    <tag k="ele" v="19.383"/>
+  </node>
+  <node id="2202" lat="35.90351252797" lon="139.93412961063">
+    <tag k="local_x" v="3817.0047"/>
+    <tag k="local_y" v="73771.3425"/>
+    <tag k="ele" v="19.351"/>
+  </node>
+  <node id="2245" lat="35.90353711192" lon="139.93337516684">
+    <tag k="local_x" v="3748.9518"/>
+    <tag k="local_y" v="73774.8124"/>
+    <tag k="ele" v="19.165"/>
+  </node>
+  <node id="2246" lat="35.90350177855" lon="139.93339847178">
+    <tag k="local_x" v="3751.0121"/>
+    <tag k="local_y" v="73770.8703"/>
+    <tag k="ele" v="19.191"/>
+  </node>
+  <node id="2247" lat="35.90346644494" lon="139.93342175011">
+    <tag k="local_x" v="3753.07"/>
+    <tag k="local_y" v="73766.9282"/>
+    <tag k="ele" v="19.222"/>
+  </node>
+  <node id="2464" lat="35.90298750075" lon="139.93299183315">
+    <tag k="local_x" v="3713.6931"/>
+    <tag k="local_y" v="73714.2279"/>
+    <tag k="ele" v="19.281"/>
+  </node>
+  <node id="3008" lat="35.90331088966" lon="139.93352719466">
+    <tag k="local_x" v="3762.3972"/>
+    <tag k="local_y" v="73749.5703"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="3009" lat="35.90333475042" lon="139.93351086097">
+    <tag k="local_x" v="3760.9521"/>
+    <tag k="local_y" v="73752.233"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3010" lat="35.90333283349" lon="139.93350647192">
+    <tag k="local_x" v="3760.5537"/>
+    <tag k="local_y" v="73752.0247"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3011" lat="35.90330897273" lon="139.93352280561">
+    <tag k="local_x" v="3761.9988"/>
+    <tag k="local_y" v="73749.362"/>
+    <tag k="ele" v="19.252"/>
+  </node>
+  <node id="3012" lat="35.90331466696" lon="139.93353600012">
+    <tag k="local_x" v="3763.1964"/>
+    <tag k="local_y" v="73749.9806"/>
+    <tag k="ele" v="19.254"/>
+  </node>
+  <node id="3013" lat="35.90333855568" lon="139.93351966717">
+    <tag k="local_x" v="3761.7514"/>
+    <tag k="local_y" v="73752.6464"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3014" lat="35.90333663965" lon="139.9335152781">
+    <tag k="local_x" v="3761.353"/>
+    <tag k="local_y" v="73752.4382"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3015" lat="35.90331277798" lon="139.9335316107">
+    <tag k="local_x" v="3762.798"/>
+    <tag k="local_y" v="73749.7754"/>
+    <tag k="ele" v="19.254"/>
+  </node>
+  <node id="3016" lat="35.90331850017" lon="139.93354480595">
+    <tag k="local_x" v="3763.9957"/>
+    <tag k="local_y" v="73750.3971"/>
+    <tag k="ele" v="19.254"/>
+  </node>
+  <node id="3017" lat="35.90334236184" lon="139.93352847224">
+    <tag k="local_x" v="3762.5506"/>
+    <tag k="local_y" v="73753.0599"/>
+    <tag k="ele" v="19.236"/>
+  </node>
+  <node id="3018" lat="35.90334047285" lon="139.93352408281">
+    <tag k="local_x" v="3762.1522"/>
+    <tag k="local_y" v="73752.8547"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3019" lat="35.90331658389" lon="139.93354038918">
+    <tag k="local_x" v="3763.5948"/>
+    <tag k="local_y" v="73750.1889"/>
+    <tag k="ele" v="19.255"/>
+  </node>
+  <node id="3020" lat="35.90332230632" lon="139.93355361102">
+    <tag k="local_x" v="3764.7949"/>
+    <tag k="local_y" v="73750.8106"/>
+    <tag k="ele" v="19.247"/>
+  </node>
+  <node id="3021" lat="35.90334616709" lon="139.93353727733">
+    <tag k="local_x" v="3763.3498"/>
+    <tag k="local_y" v="73753.4733"/>
+    <tag k="ele" v="19.217"/>
+  </node>
+  <node id="3022" lat="35.90334427811" lon="139.93353288901">
+    <tag k="local_x" v="3762.9515"/>
+    <tag k="local_y" v="73753.2681"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="3023" lat="35.90332038939" lon="139.93354922197">
+    <tag k="local_x" v="3764.3965"/>
+    <tag k="local_y" v="73750.6023"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="3024" lat="35.90332611157" lon="139.93356241611">
+    <tag k="local_x" v="3765.5941"/>
+    <tag k="local_y" v="73751.224"/>
+    <tag k="ele" v="19.237"/>
+  </node>
+  <node id="3025" lat="35.90333505577" lon="139.93355630557">
+    <tag k="local_x" v="3765.0535"/>
+    <tag k="local_y" v="73752.2221"/>
+    <tag k="ele" v="19.215"/>
+  </node>
+  <node id="3026" lat="35.9033330841" lon="139.93355194495">
+    <tag k="local_x" v="3764.6576"/>
+    <tag k="local_y" v="73752.0077"/>
+    <tag k="ele" v="19.22"/>
+  </node>
+  <node id="3027" lat="35.90332419465" lon="139.93355802816">
+    <tag k="local_x" v="3765.1958"/>
+    <tag k="local_y" v="73751.0157"/>
+    <tag k="ele" v="19.242"/>
+  </node>
+  <node id="3028" lat="35.90332991683" lon="139.93357122231">
+    <tag k="local_x" v="3766.3934"/>
+    <tag k="local_y" v="73751.6374"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="3029" lat="35.90333150026" lon="139.93357013837">
+    <tag k="local_x" v="3766.2975"/>
+    <tag k="local_y" v="73751.8141"/>
+    <tag k="ele" v="19.223"/>
+  </node>
+  <node id="3030" lat="35.90332952859" lon="139.93356577775">
+    <tag k="local_x" v="3765.9016"/>
+    <tag k="local_y" v="73751.5997"/>
+    <tag k="ele" v="19.228"/>
+  </node>
+  <node id="3031" lat="35.9033280285" lon="139.93356680517">
+    <tag k="local_x" v="3765.9925"/>
+    <tag k="local_y" v="73751.4323"/>
+    <tag k="ele" v="19.232"/>
+  </node>
+  <node id="3032" lat="35.90329183362" lon="139.93348316632">
+    <tag k="local_x" v="3758.4009"/>
+    <tag k="local_y" v="73747.5"/>
+    <tag k="ele" v="19.231"/>
+  </node>
+  <node id="3033" lat="35.90329305594" lon="139.93348233323">
+    <tag k="local_x" v="3758.3272"/>
+    <tag k="local_y" v="73747.6364"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="3034" lat="35.90329108427" lon="139.93347797262">
+    <tag k="local_x" v="3757.9313"/>
+    <tag k="local_y" v="73747.422"/>
+    <tag k="ele" v="19.224"/>
+  </node>
+  <node id="3035" lat="35.90328991759" lon="139.93347877726">
+    <tag k="local_x" v="3758.0025"/>
+    <tag k="local_y" v="73747.2918"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="3036" lat="35.90329563978" lon="139.9334919725">
+    <tag k="local_x" v="3759.2002"/>
+    <tag k="local_y" v="73747.9135"/>
+    <tag k="ele" v="19.239"/>
+  </node>
+  <node id="3037" lat="35.90330436162" lon="139.93348600013">
+    <tag k="local_x" v="3758.6718"/>
+    <tag k="local_y" v="73748.8868"/>
+    <tag k="ele" v="19.215"/>
+  </node>
+  <node id="3038" lat="35.90330238928" lon="139.93348166612">
+    <tag k="local_x" v="3758.2783"/>
+    <tag k="local_y" v="73748.6723"/>
+    <tag k="ele" v="19.211"/>
+  </node>
+  <node id="3039" lat="35.90329372285" lon="139.93348758345">
+    <tag k="local_x" v="3758.8018"/>
+    <tag k="local_y" v="73747.7052"/>
+    <tag k="ele" v="19.235"/>
+  </node>
+  <node id="3040" lat="35.90329944504" lon="139.93350077758">
+    <tag k="local_x" v="3759.9994"/>
+    <tag k="local_y" v="73748.3269"/>
+    <tag k="ele" v="19.246"/>
+  </node>
+  <node id="3041" lat="35.9033233058" lon="139.93348444499">
+    <tag k="local_x" v="3758.5544"/>
+    <tag k="local_y" v="73750.9896"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="3042" lat="35.90332141682" lon="139.93348005556">
+    <tag k="local_x" v="3758.156"/>
+    <tag k="local_y" v="73750.7844"/>
+    <tag k="ele" v="19.21"/>
+  </node>
+  <node id="3043" lat="35.90329755606" lon="139.93349638926">
+    <tag k="local_x" v="3759.6011"/>
+    <tag k="local_y" v="73748.1217"/>
+    <tag k="ele" v="19.242"/>
+  </node>
+  <node id="3044" lat="35.9033032503" lon="139.93350958377">
+    <tag k="local_x" v="3760.7987"/>
+    <tag k="local_y" v="73748.7403"/>
+    <tag k="ele" v="19.251"/>
+  </node>
+  <node id="3045" lat="35.90332711196" lon="139.93349325006">
+    <tag k="local_x" v="3759.3536"/>
+    <tag k="local_y" v="73751.4031"/>
+    <tag k="ele" v="19.239"/>
+  </node>
+  <node id="3046" lat="35.90332522297" lon="139.93348886063">
+    <tag k="local_x" v="3758.9552"/>
+    <tag k="local_y" v="73751.1979"/>
+    <tag k="ele" v="19.231"/>
+  </node>
+  <node id="3047" lat="35.90330136131" lon="139.93350519435">
+    <tag k="local_x" v="3760.4003"/>
+    <tag k="local_y" v="73748.5351"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="3048" lat="35.90330705645" lon="139.93351838885">
+    <tag k="local_x" v="3761.5979"/>
+    <tag k="local_y" v="73749.1538"/>
+    <tag k="ele" v="19.252"/>
+  </node>
+  <node id="3049" lat="35.90333094517" lon="139.93350205588">
+    <tag k="local_x" v="3760.1529"/>
+    <tag k="local_y" v="73751.8196"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="3050" lat="35.90332902824" lon="139.93349766683">
+    <tag k="local_x" v="3759.7545"/>
+    <tag k="local_y" v="73751.6113"/>
+    <tag k="ele" v="19.239"/>
+  </node>
+  <node id="3051" lat="35.90330516748" lon="139.93351400053">
+    <tag k="local_x" v="3761.1996"/>
+    <tag k="local_y" v="73748.9486"/>
+    <tag k="ele" v="19.251"/>
+  </node>
+  <node id="3052" lat="35.90330019514" lon="139.93360594418">
+    <tag k="local_x" v="3769.4908"/>
+    <tag k="local_y" v="73748.3065"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="3053" lat="35.90331308421" lon="139.93363552777">
+    <tag k="local_x" v="3772.1761"/>
+    <tag k="local_y" v="73749.707"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="3054" lat="35.90331666703" lon="139.93363319474">
+    <tag k="local_x" v="3771.9699"/>
+    <tag k="local_y" v="73750.1067"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="3055" lat="35.90330377796" lon="139.93360361116">
+    <tag k="local_x" v="3769.2846"/>
+    <tag k="local_y" v="73748.7062"/>
+    <tag k="ele" v="19.282"/>
+  </node>
+  <node id="3056" lat="35.90330736167" lon="139.93360127812">
+    <tag k="local_x" v="3769.0784"/>
+    <tag k="local_y" v="73749.106"/>
+    <tag k="ele" v="19.275"/>
+  </node>
+  <node id="3057" lat="35.90332025074" lon="139.9336308606">
+    <tag k="local_x" v="3771.7636"/>
+    <tag k="local_y" v="73750.5065"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3058" lat="35.90332383355" lon="139.93362852757">
+    <tag k="local_x" v="3771.5574"/>
+    <tag k="local_y" v="73750.9062"/>
+    <tag k="ele" v="19.263"/>
+  </node>
+  <node id="3059" lat="35.90331094448" lon="139.93359894399">
+    <tag k="local_x" v="3768.8721"/>
+    <tag k="local_y" v="73749.5057"/>
+    <tag k="ele" v="19.268"/>
+  </node>
+  <node id="3060" lat="35.90331452819" lon="139.93359661095">
+    <tag k="local_x" v="3768.6659"/>
+    <tag k="local_y" v="73749.9055"/>
+    <tag k="ele" v="19.26"/>
+  </node>
+  <node id="3061" lat="35.90331925031" lon="139.9336074449">
+    <tag k="local_x" v="3769.6493"/>
+    <tag k="local_y" v="73750.4186"/>
+    <tag k="ele" v="19.246"/>
+  </node>
+  <node id="3062" lat="35.90332283377" lon="139.93360508306">
+    <tag k="local_x" v="3769.4405"/>
+    <tag k="local_y" v="73750.8184"/>
+    <tag k="ele" v="19.238"/>
+  </node>
+  <node id="3063" lat="35.90331811191" lon="139.93359427791">
+    <tag k="local_x" v="3768.4597"/>
+    <tag k="local_y" v="73750.3053"/>
+    <tag k="ele" v="19.252"/>
+  </node>
+  <node id="3064" lat="35.90332172267" lon="139.93359194451">
+    <tag k="local_x" v="3768.2535"/>
+    <tag k="local_y" v="73750.7081"/>
+    <tag k="ele" v="19.244"/>
+  </node>
+  <node id="3065" lat="35.90332252831" lon="139.93359383303">
+    <tag k="local_x" v="3768.4249"/>
+    <tag k="local_y" v="73750.7956"/>
+    <tag k="ele" v="19.241"/>
+  </node>
+  <node id="3066" lat="35.90332611178" lon="139.93359147229">
+    <tag k="local_x" v="3768.2162"/>
+    <tag k="local_y" v="73751.1954"/>
+    <tag k="ele" v="19.233"/>
+  </node>
+  <node id="3067" lat="35.90332527843" lon="139.93358961073">
+    <tag k="local_x" v="3768.0472"/>
+    <tag k="local_y" v="73751.1048"/>
+    <tag k="ele" v="19.235"/>
+  </node>
+  <node id="3068" lat="35.90327152813" lon="139.93362461066">
+    <tag k="local_x" v="3771.1406"/>
+    <tag k="local_y" v="73745.1084"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="3069" lat="35.9032844172" lon="139.93365419423">
+    <tag k="local_x" v="3773.8259"/>
+    <tag k="local_y" v="73746.5089"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="3070" lat="35.90328800092" lon="139.9336518612">
+    <tag k="local_x" v="3773.6197"/>
+    <tag k="local_y" v="73746.9087"/>
+    <tag k="ele" v="19.302"/>
+  </node>
+  <node id="3071" lat="35.90327511185" lon="139.93362227762">
+    <tag k="local_x" v="3770.9344"/>
+    <tag k="local_y" v="73745.5082"/>
+    <tag k="ele" v="19.302"/>
+  </node>
+  <node id="3072" lat="35.90327869467" lon="139.9336199446">
+    <tag k="local_x" v="3770.7282"/>
+    <tag k="local_y" v="73745.9079"/>
+    <tag k="ele" v="19.312"/>
+  </node>
+  <node id="3073" lat="35.90329158373" lon="139.93364952817">
+    <tag k="local_x" v="3773.4135"/>
+    <tag k="local_y" v="73747.3084"/>
+    <tag k="ele" v="19.311"/>
+  </node>
+  <node id="3074" lat="35.90329516744" lon="139.93364719403">
+    <tag k="local_x" v="3773.2072"/>
+    <tag k="local_y" v="73747.7082"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="3075" lat="35.90328227838" lon="139.93361761156">
+    <tag k="local_x" v="3770.522"/>
+    <tag k="local_y" v="73746.3077"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="3076" lat="35.90328586119" lon="139.93361527743">
+    <tag k="local_x" v="3770.3157"/>
+    <tag k="local_y" v="73746.7074"/>
+    <tag k="ele" v="19.333"/>
+  </node>
+  <node id="3077" lat="35.90329875026" lon="139.93364486101">
+    <tag k="local_x" v="3773.001"/>
+    <tag k="local_y" v="73748.1079"/>
+    <tag k="ele" v="19.329"/>
+  </node>
+  <node id="3078" lat="35.90330233397" lon="139.93364252797">
+    <tag k="local_x" v="3772.7948"/>
+    <tag k="local_y" v="73748.5077"/>
+    <tag k="ele" v="19.329"/>
+  </node>
+  <node id="3079" lat="35.9032894449" lon="139.93361294439">
+    <tag k="local_x" v="3770.1095"/>
+    <tag k="local_y" v="73747.1072"/>
+    <tag k="ele" v="19.332"/>
+  </node>
+  <node id="3080" lat="35.90329302862" lon="139.93361061135">
+    <tag k="local_x" v="3769.9033"/>
+    <tag k="local_y" v="73747.507"/>
+    <tag k="ele" v="19.319"/>
+  </node>
+  <node id="3081" lat="35.90330591679" lon="139.93364019495">
+    <tag k="local_x" v="3772.5886"/>
+    <tag k="local_y" v="73748.9074"/>
+    <tag k="ele" v="19.318"/>
+  </node>
+  <node id="3082" lat="35.9033095005" lon="139.9336378608">
+    <tag k="local_x" v="3772.3823"/>
+    <tag k="local_y" v="73749.3072"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="3083" lat="35.90329661143" lon="139.93360827722">
+    <tag k="local_x" v="3769.697"/>
+    <tag k="local_y" v="73747.9067"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="3084" lat="35.90325002856" lon="139.93363861105">
+    <tag k="local_x" v="3772.378"/>
+    <tag k="local_y" v="73742.7099"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3085" lat="35.90325100058" lon="139.9336408608">
+    <tag k="local_x" v="3772.5822"/>
+    <tag k="local_y" v="73742.8155"/>
+    <tag k="ele" v="19.272"/>
+  </node>
+  <node id="3086" lat="35.90325458405" lon="139.93363850007">
+    <tag k="local_x" v="3772.3735"/>
+    <tag k="local_y" v="73743.2153"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3087" lat="35.90325361137" lon="139.93363627803">
+    <tag k="local_x" v="3772.1718"/>
+    <tag k="local_y" v="73743.1096"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="3088" lat="35.90325719508" lon="139.93363394388">
+    <tag k="local_x" v="3771.9655"/>
+    <tag k="local_y" v="73743.5094"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="3089" lat="35.90326186121" lon="139.93364466667">
+    <tag k="local_x" v="3772.9388"/>
+    <tag k="local_y" v="73744.0164"/>
+    <tag k="ele" v="19.266"/>
+  </node>
+  <node id="3090" lat="35.90326544468" lon="139.93364230593">
+    <tag k="local_x" v="3772.7301"/>
+    <tag k="local_y" v="73744.4162"/>
+    <tag k="ele" v="19.268"/>
+  </node>
+  <node id="3091" lat="35.90326077789" lon="139.93363161086">
+    <tag k="local_x" v="3771.7593"/>
+    <tag k="local_y" v="73743.9091"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="3092" lat="35.90326436161" lon="139.93362927783">
+    <tag k="local_x" v="3771.5531"/>
+    <tag k="local_y" v="73744.3089"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="3093" lat="35.90327725068" lon="139.9336588614">
+    <tag k="local_x" v="3774.2384"/>
+    <tag k="local_y" v="73745.7094"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3094" lat="35.90328083348" lon="139.93365652727">
+    <tag k="local_x" v="3774.0321"/>
+    <tag k="local_y" v="73746.1091"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="3095" lat="35.90326794533" lon="139.93362694479">
+    <tag k="local_x" v="3771.3469"/>
+    <tag k="local_y" v="73744.7087"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="3096" lat="35.90319858351" lon="139.93354955535">
+    <tag k="local_x" v="3764.2791"/>
+    <tag k="local_y" v="73737.0914"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="3097" lat="35.90319002813" lon="139.93355538918">
+    <tag k="local_x" v="3764.7952"/>
+    <tag k="local_y" v="73736.1367"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="3098" lat="35.90319202866" lon="139.93355975051">
+    <tag k="local_x" v="3765.1912"/>
+    <tag k="local_y" v="73736.3543"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="3099" lat="35.90320050044" lon="139.9335539444">
+    <tag k="local_x" v="3764.6775"/>
+    <tag k="local_y" v="73737.2997"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="3100" lat="35.90319475055" lon="139.93354077725">
+    <tag k="local_x" v="3763.4823"/>
+    <tag k="local_y" v="73736.6749"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="3101" lat="35.90319333358" lon="139.93354172265">
+    <tag k="local_x" v="3763.5659"/>
+    <tag k="local_y" v="73736.5168"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="3102" lat="35.9031953341" lon="139.93354608287">
+    <tag k="local_x" v="3763.9618"/>
+    <tag k="local_y" v="73736.7344"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="3103" lat="35.90319666748" lon="139.93354516629">
+    <tag k="local_x" v="3763.8807"/>
+    <tag k="local_y" v="73736.8832"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="3104" lat="35.90323305583" lon="139.93362866617">
+    <tag k="local_x" v="3771.46"/>
+    <tag k="local_y" v="73740.8371"/>
+    <tag k="ele" v="19.287"/>
+  </node>
+  <node id="3105" lat="35.90323158345" lon="139.93362966662">
+    <tag k="local_x" v="3771.5485"/>
+    <tag k="local_y" v="73740.6728"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="3106" lat="35.90323355602" lon="139.93363402722">
+    <tag k="local_x" v="3771.9444"/>
+    <tag k="local_y" v="73740.8873"/>
+    <tag k="ele" v="19.281"/>
+  </node>
+  <node id="3107" lat="35.90323497275" lon="139.93363305523">
+    <tag k="local_x" v="3771.8584"/>
+    <tag k="local_y" v="73741.0454"/>
+    <tag k="ele" v="19.282"/>
+  </node>
+  <node id="3108" lat="35.90322925058" lon="139.93361986109">
+    <tag k="local_x" v="3770.6608"/>
+    <tag k="local_y" v="73740.4237"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="3109" lat="35.90322019533" lon="139.93362605511">
+    <tag k="local_x" v="3771.2088"/>
+    <tag k="local_y" v="73739.4132"/>
+    <tag k="ele" v="19.291"/>
+  </node>
+  <node id="3110" lat="35.90322216701" lon="139.93363041683">
+    <tag k="local_x" v="3771.6048"/>
+    <tag k="local_y" v="73739.6276"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="3111" lat="35.90323113981" lon="139.93362427822">
+    <tag k="local_x" v="3771.0617"/>
+    <tag k="local_y" v="73740.6289"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="3112" lat="35.90322541673" lon="139.93361108299">
+    <tag k="local_x" v="3769.864"/>
+    <tag k="local_y" v="73740.0071"/>
+    <tag k="ele" v="19.314"/>
+  </node>
+  <node id="3113" lat="35.90320152801" lon="139.93362741701">
+    <tag k="local_x" v="3771.3091"/>
+    <tag k="local_y" v="73737.3413"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="3114" lat="35.90320344493" lon="139.93363180606">
+    <tag k="local_x" v="3771.7075"/>
+    <tag k="local_y" v="73737.5496"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="3115" lat="35.90322733365" lon="139.93361547204">
+    <tag k="local_x" v="3770.2624"/>
+    <tag k="local_y" v="73740.2154"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="3116" lat="35.90322158354" lon="139.93360227828">
+    <tag k="local_x" v="3769.0648"/>
+    <tag k="local_y" v="73739.5906"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="3117" lat="35.90319769481" lon="139.93361861119">
+    <tag k="local_x" v="3770.5098"/>
+    <tag k="local_y" v="73736.9248"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="3118" lat="35.90319961198" lon="139.93362302794">
+    <tag k="local_x" v="3770.9107"/>
+    <tag k="local_y" v="73737.1331"/>
+    <tag k="ele" v="19.319"/>
+  </node>
+  <node id="3119" lat="35.9032235007" lon="139.93360669393">
+    <tag k="local_x" v="3769.4656"/>
+    <tag k="local_y" v="73739.7989"/>
+    <tag k="ele" v="19.323"/>
+  </node>
+  <node id="3120" lat="35.90321775058" lon="139.93359350017">
+    <tag k="local_x" v="3768.268"/>
+    <tag k="local_y" v="73739.1741"/>
+    <tag k="ele" v="19.321"/>
+  </node>
+  <node id="3121" lat="35.90319388981" lon="139.93360983382">
+    <tag k="local_x" v="3769.7131"/>
+    <tag k="local_y" v="73736.5114"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="3122" lat="35.90319580582" lon="139.93361422177">
+    <tag k="local_x" v="3770.1114"/>
+    <tag k="local_y" v="73736.7196"/>
+    <tag k="ele" v="19.327"/>
+  </node>
+  <node id="3123" lat="35.90321966751" lon="139.93359788922">
+    <tag k="local_x" v="3768.6664"/>
+    <tag k="local_y" v="73739.3824"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="3124" lat="35.90321391738" lon="139.93358469436">
+    <tag k="local_x" v="3767.4687"/>
+    <tag k="local_y" v="73738.7576"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="3125" lat="35.90319005571" lon="139.93360102802">
+    <tag k="local_x" v="3768.9138"/>
+    <tag k="local_y" v="73736.0948"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="3126" lat="35.90319197288" lon="139.93360544477">
+    <tag k="local_x" v="3769.3147"/>
+    <tag k="local_y" v="73736.3031"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="3127" lat="35.90321583365" lon="139.93358911112">
+    <tag k="local_x" v="3767.8696"/>
+    <tag k="local_y" v="73738.9658"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="3128" lat="35.90321008352" lon="139.93357591626">
+    <tag k="local_x" v="3766.6719"/>
+    <tag k="local_y" v="73738.341"/>
+    <tag k="ele" v="19.319"/>
+  </node>
+  <node id="3129" lat="35.90318622275" lon="139.93359224991">
+    <tag k="local_x" v="3768.117"/>
+    <tag k="local_y" v="73735.6783"/>
+    <tag k="ele" v="19.324"/>
+  </node>
+  <node id="3130" lat="35.90318813968" lon="139.93359663896">
+    <tag k="local_x" v="3768.5154"/>
+    <tag k="local_y" v="73735.8866"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="3131" lat="35.90321200045" lon="139.93358030531">
+    <tag k="local_x" v="3767.0703"/>
+    <tag k="local_y" v="73738.5493"/>
+    <tag k="ele" v="19.319"/>
+  </node>
+  <node id="3132" lat="35.90320625057" lon="139.93356713926">
+    <tag k="local_x" v="3765.8752"/>
+    <tag k="local_y" v="73737.9245"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="3133" lat="35.90318238979" lon="139.9335834718">
+    <tag k="local_x" v="3767.3202"/>
+    <tag k="local_y" v="73735.2618"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="3134" lat="35.90318430582" lon="139.93358786086">
+    <tag k="local_x" v="3767.7186"/>
+    <tag k="local_y" v="73735.47"/>
+    <tag k="ele" v="19.324"/>
+  </node>
+  <node id="3135" lat="35.9032081675" lon="139.93357152831">
+    <tag k="local_x" v="3766.2736"/>
+    <tag k="local_y" v="73738.1328"/>
+    <tag k="ele" v="19.318"/>
+  </node>
+  <node id="3136" lat="35.90320241737" lon="139.93355833345">
+    <tag k="local_x" v="3765.0759"/>
+    <tag k="local_y" v="73737.508"/>
+    <tag k="ele" v="19.302"/>
+  </node>
+  <node id="3137" lat="35.9031785557" lon="139.93357466711">
+    <tag k="local_x" v="3766.521"/>
+    <tag k="local_y" v="73734.8452"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="3138" lat="35.90318047288" lon="139.93357908386">
+    <tag k="local_x" v="3766.9219"/>
+    <tag k="local_y" v="73735.0535"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="3139" lat="35.90320433365" lon="139.93356275021">
+    <tag k="local_x" v="3765.4768"/>
+    <tag k="local_y" v="73737.7162"/>
+    <tag k="ele" v="19.31"/>
+  </node>
+  <node id="3140" lat="35.90320291756" lon="139.93351963878">
+    <tag k="local_x" v="3761.5846"/>
+    <tag k="local_y" v="73737.6016"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="3141" lat="35.90320216684" lon="139.93351794456">
+    <tag k="local_x" v="3761.4308"/>
+    <tag k="local_y" v="73737.52"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="3142" lat="35.90319861198" lon="139.93352027721">
+    <tag k="local_x" v="3761.637"/>
+    <tag k="local_y" v="73737.1234"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3143" lat="35.90319933385" lon="139.93352197182">
+    <tag k="local_x" v="3761.7908"/>
+    <tag k="local_y" v="73737.2018"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="3144" lat="35.90321005565" lon="139.93351491659">
+    <tag k="local_x" v="3761.1671"/>
+    <tag k="local_y" v="73738.398"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="3145" lat="35.9032052782" lon="139.93350394488">
+    <tag k="local_x" v="3760.1712"/>
+    <tag k="local_y" v="73737.8789"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3146" lat="35.90320169449" lon="139.93350627792">
+    <tag k="local_x" v="3760.3774"/>
+    <tag k="local_y" v="73737.4791"/>
+    <tag k="ele" v="19.27"/>
+  </node>
+  <node id="3147" lat="35.90320647308" lon="139.93351727731">
+    <tag k="local_x" v="3761.3758"/>
+    <tag k="local_y" v="73737.9983"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="3148" lat="35.90321722282" lon="139.9335102217">
+    <tag k="local_x" v="3760.7521"/>
+    <tag k="local_y" v="73739.1976"/>
+    <tag k="ele" v="19.301"/>
+  </node>
+  <node id="3149" lat="35.90320433348" lon="139.93348061158">
+    <tag k="local_x" v="3758.0644"/>
+    <tag k="local_y" v="73737.7971"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="3150" lat="35.90320075092" lon="139.93348297231">
+    <tag k="local_x" v="3758.2731"/>
+    <tag k="local_y" v="73737.3974"/>
+    <tag k="ele" v="19.271"/>
+  </node>
+  <node id="3151" lat="35.90321363911" lon="139.93351255585">
+    <tag k="local_x" v="3760.9584"/>
+    <tag k="local_y" v="73738.7978"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="3152" lat="35.9032243618" lon="139.93350549949">
+    <tag k="local_x" v="3760.3346"/>
+    <tag k="local_y" v="73739.9941"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="3153" lat="35.90321147246" lon="139.93347588937">
+    <tag k="local_x" v="3757.6469"/>
+    <tag k="local_y" v="73738.5936"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="3154" lat="35.90320788899" lon="139.93347825011">
+    <tag k="local_x" v="3757.8556"/>
+    <tag k="local_y" v="73738.1938"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="3155" lat="35.90322077834" lon="139.93350786134">
+    <tag k="local_x" v="3760.5434"/>
+    <tag k="local_y" v="73739.5943"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="3156" lat="35.90323150078" lon="139.93350077728">
+    <tag k="local_x" v="3759.9171"/>
+    <tag k="local_y" v="73740.7906"/>
+    <tag k="ele" v="19.332"/>
+  </node>
+  <node id="3157" lat="35.90321861169" lon="139.93347119485">
+    <tag k="local_x" v="3757.2319"/>
+    <tag k="local_y" v="73739.3901"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="3158" lat="35.90321505617" lon="139.93347355522">
+    <tag k="local_x" v="3757.4406"/>
+    <tag k="local_y" v="73738.9934"/>
+    <tag k="ele" v="19.315"/>
+  </node>
+  <node id="3159" lat="35.90322794527" lon="139.93350313875">
+    <tag k="local_x" v="3760.1259"/>
+    <tag k="local_y" v="73740.3939"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="3160" lat="35.90323866706" lon="139.93349608351">
+    <tag k="local_x" v="3759.5022"/>
+    <tag k="local_y" v="73741.5901"/>
+    <tag k="ele" v="19.336"/>
+  </node>
+  <node id="3161" lat="35.90322577862" lon="139.93346647226">
+    <tag k="local_x" v="3756.8144"/>
+    <tag k="local_y" v="73740.1897"/>
+    <tag k="ele" v="19.334"/>
+  </node>
+  <node id="3162" lat="35.90322219515" lon="139.93346883301">
+    <tag k="local_x" v="3757.0231"/>
+    <tag k="local_y" v="73739.7899"/>
+    <tag k="ele" v="19.334"/>
+  </node>
+  <node id="3163" lat="35.9032350836" lon="139.93349844425">
+    <tag k="local_x" v="3759.7109"/>
+    <tag k="local_y" v="73741.1903"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="3164" lat="35.90324580605" lon="139.93349136129">
+    <tag k="local_x" v="3759.0847"/>
+    <tag k="local_y" v="73742.3866"/>
+    <tag k="ele" v="19.316"/>
+  </node>
+  <node id="3165" lat="35.90323291694" lon="139.93346177776">
+    <tag k="local_x" v="3756.3994"/>
+    <tag k="local_y" v="73740.9861"/>
+    <tag k="ele" v="19.316"/>
+  </node>
+  <node id="3166" lat="35.90322936143" lon="139.93346413923">
+    <tag k="local_x" v="3756.6082"/>
+    <tag k="local_y" v="73740.5894"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="3167" lat="35.90324225052" lon="139.93349372166">
+    <tag k="local_x" v="3759.2934"/>
+    <tag k="local_y" v="73741.9899"/>
+    <tag k="ele" v="19.327"/>
+  </node>
+  <node id="3168" lat="35.90325297232" lon="139.93348666641">
+    <tag k="local_x" v="3758.6697"/>
+    <tag k="local_y" v="73743.1861"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="3169" lat="35.90324008387" lon="139.93345705517">
+    <tag k="local_x" v="3755.9819"/>
+    <tag k="local_y" v="73741.7857"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="3170" lat="35.90323650041" lon="139.93345941702">
+    <tag k="local_x" v="3756.1907"/>
+    <tag k="local_y" v="73741.3859"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="3171" lat="35.9032493895" lon="139.93348899944">
+    <tag k="local_x" v="3758.8759"/>
+    <tag k="local_y" v="73742.7864"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="3172" lat="35.9032601113" lon="139.9334819442">
+    <tag k="local_x" v="3758.2522"/>
+    <tag k="local_y" v="73743.9826"/>
+    <tag k="ele" v="19.274"/>
+  </node>
+  <node id="3173" lat="35.90324722309" lon="139.93345236065">
+    <tag k="local_x" v="3755.5669"/>
+    <tag k="local_y" v="73742.5822"/>
+    <tag k="ele" v="19.263"/>
+  </node>
+  <node id="3174" lat="35.90324363939" lon="139.9334546948">
+    <tag k="local_x" v="3755.7732"/>
+    <tag k="local_y" v="73742.1824"/>
+    <tag k="ele" v="19.281"/>
+  </node>
+  <node id="3175" lat="35.90325652784" lon="139.93348430605">
+    <tag k="local_x" v="3758.461"/>
+    <tag k="local_y" v="73743.5828"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="3176" lat="35.90326725028" lon="139.93347722198">
+    <tag k="local_x" v="3757.8347"/>
+    <tag k="local_y" v="73744.7791"/>
+    <tag k="ele" v="19.256"/>
+  </node>
+  <node id="3177" lat="35.90326250037" lon="139.9334663053">
+    <tag k="local_x" v="3756.8438"/>
+    <tag k="local_y" v="73744.263"/>
+    <tag k="ele" v="19.244"/>
+  </node>
+  <node id="3178" lat="35.90325891755" lon="139.93346863833">
+    <tag k="local_x" v="3757.05"/>
+    <tag k="local_y" v="73743.8633"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="3179" lat="35.90326369477" lon="139.93347958346">
+    <tag k="local_x" v="3758.0435"/>
+    <tag k="local_y" v="73744.3824"/>
+    <tag k="ele" v="19.265"/>
+  </node>
+  <node id="4986" lat="35.90303141689" lon="139.93295655606">
+    <tag k="local_x" v="3710.5628"/>
+    <tag k="local_y" v="73719.1338"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="4987" lat="35.90302997249" lon="139.93295147255">
+    <tag k="local_x" v="3710.1023"/>
+    <tag k="local_y" v="73718.9786"/>
+    <tag k="ele" v="19.287"/>
+  </node>
+  <node id="4988" lat="35.90302891683" lon="139.93294630514">
+    <tag k="local_x" v="3709.6347"/>
+    <tag k="local_y" v="73718.8666"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="4989" lat="35.90302825081" lon="139.93294105604">
+    <tag k="local_x" v="3709.1602"/>
+    <tag k="local_y" v="73718.7979"/>
+    <tag k="ele" v="19.273"/>
+  </node>
+  <node id="4990" lat="35.90302800081" lon="139.93293575039">
+    <tag k="local_x" v="3708.6811"/>
+    <tag k="local_y" v="73718.7754"/>
+    <tag k="ele" v="19.27"/>
+  </node>
+  <node id="4991" lat="35.90302813913" lon="139.93293041624">
+    <tag k="local_x" v="3708.1999"/>
+    <tag k="local_y" v="73718.796"/>
+    <tag k="ele" v="19.265"/>
+  </node>
+  <node id="4992" lat="35.90302866743" lon="139.93292513892">
+    <tag k="local_x" v="3707.7243"/>
+    <tag k="local_y" v="73718.8598"/>
+    <tag k="ele" v="19.261"/>
+  </node>
+  <node id="4993" lat="35.90302961118" lon="139.93291994467">
+    <tag k="local_x" v="3707.2567"/>
+    <tag k="local_y" v="73718.9696"/>
+    <tag k="ele" v="19.256"/>
+  </node>
+  <node id="4994" lat="35.90303094449" lon="139.93291486155">
+    <tag k="local_x" v="3706.7996"/>
+    <tag k="local_y" v="73719.1225"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="4995" lat="35.9030326672" lon="139.93290997266">
+    <tag k="local_x" v="3706.3605"/>
+    <tag k="local_y" v="73719.3184"/>
+    <tag k="ele" v="19.245"/>
+  </node>
+  <node id="4996" lat="35.90303472275" lon="139.93290530535">
+    <tag k="local_x" v="3705.9418"/>
+    <tag k="local_y" v="73719.551"/>
+    <tag k="ele" v="19.239"/>
+  </node>
+  <node id="4997" lat="35.90303713911" lon="139.93290086148">
+    <tag k="local_x" v="3705.5437"/>
+    <tag k="local_y" v="73719.8234"/>
+    <tag k="ele" v="19.232"/>
+  </node>
+  <node id="4998" lat="35.90303988929" lon="139.93289674999">
+    <tag k="local_x" v="3705.176"/>
+    <tag k="local_y" v="73720.1325"/>
+    <tag k="ele" v="19.225"/>
+  </node>
+  <node id="4999" lat="35.90304291717" lon="139.93289294394">
+    <tag k="local_x" v="3704.8362"/>
+    <tag k="local_y" v="73720.4721"/>
+    <tag k="ele" v="19.232"/>
+  </node>
+  <node id="5000" lat="35.90304608342" lon="139.93288969452">
+    <tag k="local_x" v="3704.5468"/>
+    <tag k="local_y" v="73720.8265"/>
+    <tag k="ele" v="19.237"/>
+  </node>
+  <node id="5007" lat="35.90303525008" lon="139.93286086146">
+    <tag k="local_x" v="3701.9317"/>
+    <tag k="local_y" v="73719.6533"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="5008" lat="35.90302994506" lon="139.93286550037">
+    <tag k="local_x" v="3702.3439"/>
+    <tag k="local_y" v="73719.0603"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="5009" lat="35.90302480587" lon="139.93287094487">
+    <tag k="local_x" v="3702.829"/>
+    <tag k="local_y" v="73718.4849"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="5010" lat="35.90302008387" lon="139.93287697218">
+    <tag k="local_x" v="3703.3672"/>
+    <tag k="local_y" v="73717.9552"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="5011" lat="35.90301586128" lon="139.9328835003">
+    <tag k="local_x" v="3703.9512"/>
+    <tag k="local_y" v="73717.4804"/>
+    <tag k="ele" v="19.291"/>
+  </node>
+  <node id="5012" lat="35.90301213964" lon="139.93289050041">
+    <tag k="local_x" v="3704.5784"/>
+    <tag k="local_y" v="73717.0607"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="5013" lat="35.90300897231" lon="139.93289788867">
+    <tag k="local_x" v="3705.2413"/>
+    <tag k="local_y" v="73716.7021"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="5014" lat="35.90300636125" lon="139.93290558306">
+    <tag k="local_x" v="3705.9325"/>
+    <tag k="local_y" v="73716.4049"/>
+    <tag k="ele" v="19.287"/>
+  </node>
+  <node id="5015" lat="35.90300433351" lon="139.93291358322">
+    <tag k="local_x" v="3706.652"/>
+    <tag k="local_y" v="73716.1721"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="5016" lat="35.90300294466" lon="139.93292174989">
+    <tag k="local_x" v="3707.3873"/>
+    <tag k="local_y" v="73716.01"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="5017" lat="35.9030021674" lon="139.93293005572">
+    <tag k="local_x" v="3708.1359"/>
+    <tag k="local_y" v="73715.9156"/>
+    <tag k="ele" v="19.3"/>
+  </node>
+  <node id="5018" lat="35.90300202868" lon="139.93293838844">
+    <tag k="local_x" v="3708.8877"/>
+    <tag k="local_y" v="73715.892"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="5019" lat="35.90300250032" lon="139.93294672183">
+    <tag k="local_x" v="3709.6403"/>
+    <tag k="local_y" v="73715.9361"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="5020" lat="35.90300361133" lon="139.9329549724">
+    <tag k="local_x" v="3710.3862"/>
+    <tag k="local_y" v="73716.0512"/>
+    <tag k="ele" v="19.324"/>
+  </node>
+  <node id="5021" lat="35.90300533392" lon="139.93296305519">
+    <tag k="local_x" v="3711.1177"/>
+    <tag k="local_y" v="73716.2343"/>
+    <tag k="ele" v="19.33"/>
+  </node>
+  <node id="5022" lat="35.90300766685" lon="139.9329708328">
+    <tag k="local_x" v="3711.8224"/>
+    <tag k="local_y" v="73716.4854"/>
+    <tag k="ele" v="19.335"/>
+  </node>
+  <node id="5026" lat="35.90302175009" lon="139.93283225038">
+    <tag k="local_x" v="3699.3334"/>
+    <tag k="local_y" v="73718.1841"/>
+    <tag k="ele" v="19.228"/>
+  </node>
+  <node id="5027" lat="35.90301494483" lon="139.93283799982">
+    <tag k="local_x" v="3699.844"/>
+    <tag k="local_y" v="73717.4236"/>
+    <tag k="ele" v="19.235"/>
+  </node>
+  <node id="5028" lat="35.90300777859" lon="139.93284533318">
+    <tag k="local_x" v="3700.4971"/>
+    <tag k="local_y" v="73716.6215"/>
+    <tag k="ele" v="19.244"/>
+  </node>
+  <node id="5029" lat="35.90300122265" lon="139.93285347171">
+    <tag k="local_x" v="3701.2236"/>
+    <tag k="local_y" v="73715.8863"/>
+    <tag k="ele" v="19.255"/>
+  </node>
+  <node id="5030" lat="35.90299530578" lon="139.93286230531">
+    <tag k="local_x" v="3702.0136"/>
+    <tag k="local_y" v="73715.2213"/>
+    <tag k="ele" v="19.262"/>
+  </node>
+  <node id="5031" lat="35.90299005634" lon="139.9328717782">
+    <tag k="local_x" v="3702.8621"/>
+    <tag k="local_y" v="73714.6297"/>
+    <tag k="ele" v="19.282"/>
+  </node>
+  <node id="5032" lat="35.90298555587" lon="139.93288183388">
+    <tag k="local_x" v="3703.7641"/>
+    <tag k="local_y" v="73714.1206"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="5033" lat="35.90298183377" lon="139.93289233343">
+    <tag k="local_x" v="3704.7071"/>
+    <tag k="local_y" v="73713.6974"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="5034" lat="35.90297894457" lon="139.93290322184">
+    <tag k="local_x" v="3705.6862"/>
+    <tag k="local_y" v="73713.3662"/>
+    <tag k="ele" v="19.33"/>
+  </node>
+  <node id="5035" lat="35.90297686203" lon="139.93291438864">
+    <tag k="local_x" v="3706.6914"/>
+    <tag k="local_y" v="73713.1242"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="5036" lat="35.90297563951" lon="139.93292574999">
+    <tag k="local_x" v="3707.7152"/>
+    <tag k="local_y" v="73712.9774"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="5037" lat="35.90297530576" lon="139.93293719472">
+    <tag k="local_x" v="3708.7476"/>
+    <tag k="local_y" v="73712.9291"/>
+    <tag k="ele" v="19.31"/>
+  </node>
+  <node id="5038" lat="35.90297580595" lon="139.93294863933">
+    <tag k="local_x" v="3709.781"/>
+    <tag k="local_y" v="73712.9733"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="5039" lat="35.90297716704" lon="139.93295997265">
+    <tag k="local_x" v="3710.8054"/>
+    <tag k="local_y" v="73713.1131"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="5040" lat="35.90297938895" lon="139.93297108388">
+    <tag k="local_x" v="3711.8108"/>
+    <tag k="local_y" v="73713.3486"/>
+    <tag k="ele" v="19.301"/>
+  </node>
+  <node id="5041" lat="35.90298241741" lon="139.93298174989">
+    <tag k="local_x" v="3712.777"/>
+    <tag k="local_y" v="73713.674"/>
+    <tag k="ele" v="19.299"/>
+  </node>
+  <node id="5066" lat="35.90302891722" lon="139.93295263916">
+    <tag k="local_x" v="3710.2063"/>
+    <tag k="local_y" v="73718.8604"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5067" lat="35.9030249728" lon="139.93294522226">
+    <tag k="local_x" v="3709.5322"/>
+    <tag k="local_y" v="73718.4302"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="5068" lat="35.90302088946" lon="139.93293800004">
+    <tag k="local_x" v="3708.8755"/>
+    <tag k="local_y" v="73717.9844"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="5069" lat="35.90301502846" lon="139.93292958387">
+    <tag k="local_x" v="3708.1089"/>
+    <tag k="local_y" v="73717.3426"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="5070" lat="35.9030085559" lon="139.93292194494">
+    <tag k="local_x" v="3707.4117"/>
+    <tag k="local_y" v="73716.6322"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="5071" lat="35.90300147292" lon="139.93291511094">
+    <tag k="local_x" v="3706.7864"/>
+    <tag k="local_y" v="73715.8533"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="5072" lat="35.90299388961" lon="139.93290919454">
+    <tag k="local_x" v="3706.2433"/>
+    <tag k="local_y" v="73715.018"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="5073" lat="35.90298586122" lon="139.9329042227">
+    <tag k="local_x" v="3705.7849"/>
+    <tag k="local_y" v="73714.1324"/>
+    <tag k="ele" v="19.323"/>
+  </node>
+  <node id="5074" lat="35.90297744501" lon="139.93290025004">
+    <tag k="local_x" v="3705.4162"/>
+    <tag k="local_y" v="73713.2028"/>
+    <tag k="ele" v="19.332"/>
+  </node>
+  <node id="5075" lat="35.90296877854" lon="139.93289733347">
+    <tag k="local_x" v="3705.1425"/>
+    <tag k="local_y" v="73712.2444"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="5076" lat="35.90295991705" lon="139.93289549993">
+    <tag k="local_x" v="3704.9663"/>
+    <tag k="local_y" v="73711.2633"/>
+    <tag k="ele" v="19.314"/>
+  </node>
+  <node id="5077" lat="35.90295094528" lon="139.93289475051">
+    <tag k="local_x" v="3704.8878"/>
+    <tag k="local_y" v="73710.2689"/>
+    <tag k="ele" v="19.302"/>
+  </node>
+  <node id="5078" lat="35.9029419446" lon="139.9328951107">
+    <tag k="local_x" v="3704.9094"/>
+    <tag k="local_y" v="73709.2702"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="5079" lat="35.90293302839" lon="139.93289655572">
+    <tag k="local_x" v="3705.029"/>
+    <tag k="local_y" v="73708.2798"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5080" lat="35.90292427803" lon="139.93289911106">
+    <tag k="local_x" v="3705.249"/>
+    <tag k="local_y" v="73707.3067"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5081" lat="35.90291722269" lon="139.93290208357">
+    <tag k="local_x" v="3705.5087"/>
+    <tag k="local_y" v="73706.5212"/>
+    <tag k="ele" v="19.291"/>
+  </node>
+  <node id="5082" lat="35.90290444517" lon="139.93290799961">
+    <tag k="local_x" v="3706.0271"/>
+    <tag k="local_y" v="73705.0981"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="5086" lat="35.90291547279" lon="139.93293800019">
+    <tag k="local_x" v="3708.7478"/>
+    <tag k="local_y" v="73706.2917"/>
+    <tag k="ele" v="19.358"/>
+  </node>
+  <node id="5087" lat="35.90292627813" lon="139.93293294394">
+    <tag k="local_x" v="3708.3046"/>
+    <tag k="local_y" v="73707.4952"/>
+    <tag k="ele" v="19.353"/>
+  </node>
+  <node id="5088" lat="35.9029316952" lon="139.93293066717">
+    <tag k="local_x" v="3708.1057"/>
+    <tag k="local_y" v="73708.0983"/>
+    <tag k="ele" v="19.35"/>
+  </node>
+  <node id="5089" lat="35.9029378618" lon="139.93292883355">
+    <tag k="local_x" v="3707.9477"/>
+    <tag k="local_y" v="73708.7841"/>
+    <tag k="ele" v="19.346"/>
+  </node>
+  <node id="5090" lat="35.90294413924" lon="139.93292780515">
+    <tag k="local_x" v="3707.8625"/>
+    <tag k="local_y" v="73709.4814"/>
+    <tag k="ele" v="19.34"/>
+  </node>
+  <node id="5091" lat="35.90295050089" lon="139.93292752804">
+    <tag k="local_x" v="3707.8452"/>
+    <tag k="local_y" v="73710.1873"/>
+    <tag k="ele" v="19.335"/>
+  </node>
+  <node id="5092" lat="35.90295683338" lon="139.93292802812">
+    <tag k="local_x" v="3707.898"/>
+    <tag k="local_y" v="73710.8892"/>
+    <tag k="ele" v="19.33"/>
+  </node>
+  <node id="5093" lat="35.90296308378" lon="139.93292933379">
+    <tag k="local_x" v="3708.0234"/>
+    <tag k="local_y" v="73711.5812"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="5094" lat="35.90296919454" lon="139.93293136161">
+    <tag k="local_x" v="3708.2138"/>
+    <tag k="local_y" v="73712.257"/>
+    <tag k="ele" v="19.319"/>
+  </node>
+  <node id="5095" lat="35.90297513976" lon="139.93293413853">
+    <tag k="local_x" v="3708.4716"/>
+    <tag k="local_y" v="73712.9137"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="5096" lat="35.90298080626" lon="139.93293761067">
+    <tag k="local_x" v="3708.7918"/>
+    <tag k="local_y" v="73713.5388"/>
+    <tag k="ele" v="19.31"/>
+  </node>
+  <node id="5097" lat="35.902986167" lon="139.93294177726">
+    <tag k="local_x" v="3709.1743"/>
+    <tag k="local_y" v="73714.1293"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="5098" lat="35.90299116739" lon="139.93294658365">
+    <tag k="local_x" v="3709.6141"/>
+    <tag k="local_y" v="73714.6792"/>
+    <tag k="ele" v="19.314"/>
+  </node>
+  <node id="5099" lat="35.90299575012" lon="139.93295197187">
+    <tag k="local_x" v="3710.1059"/>
+    <tag k="local_y" v="73715.1822"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="5100" lat="35.90299988947" lon="139.93295788908">
+    <tag k="local_x" v="3710.6449"/>
+    <tag k="local_y" v="73715.6355"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="5101" lat="35.90300308421" lon="139.93296352753">
+    <tag k="local_x" v="3711.1576"/>
+    <tag k="local_y" v="73715.9843"/>
+    <tag k="ele" v="19.33"/>
+  </node>
+  <node id="5102" lat="35.90300797286" lon="139.93297249974">
+    <tag k="local_x" v="3711.9732"/>
+    <tag k="local_y" v="73716.5177"/>
+    <tag k="ele" v="19.336"/>
+  </node>
+  <node id="5107" lat="35.90293541718" lon="139.93296408355">
+    <tag k="local_x" v="3711.1258"/>
+    <tag k="local_y" v="73708.4782"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="5108" lat="35.90293919482" lon="139.93296247261">
+    <tag k="local_x" v="3710.985"/>
+    <tag k="local_y" v="73708.8988"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="5109" lat="35.90294277841" lon="139.93296144492">
+    <tag k="local_x" v="3710.8966"/>
+    <tag k="local_y" v="73709.2973"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5110" lat="35.90294641707" lon="139.93296083315">
+    <tag k="local_x" v="3710.8458"/>
+    <tag k="local_y" v="73709.7015"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="5111" lat="35.90295008404" lon="139.93296066646">
+    <tag k="local_x" v="3710.8352"/>
+    <tag k="local_y" v="73710.1084"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="5112" lat="35.90295377865" lon="139.93296097256">
+    <tag k="local_x" v="3710.8673"/>
+    <tag k="local_y" v="73710.5179"/>
+    <tag k="ele" v="19.296"/>
+  </node>
+  <node id="5113" lat="35.9029573895" lon="139.93296169423">
+    <tag k="local_x" v="3710.9368"/>
+    <tag k="local_y" v="73710.9177"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5114" lat="35.90296094504" lon="139.93296288871">
+    <tag k="local_x" v="3711.0489"/>
+    <tag k="local_y" v="73711.3109"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="5115" lat="35.90296436184" lon="139.93296449948">
+    <tag k="local_x" v="3711.1984"/>
+    <tag k="local_y" v="73711.6883"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="5116" lat="35.90296766695" lon="139.93296652729">
+    <tag k="local_x" v="3711.3854"/>
+    <tag k="local_y" v="73712.0529"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="5117" lat="35.90297077808" lon="139.93296894445">
+    <tag k="local_x" v="3711.6073"/>
+    <tag k="local_y" v="73712.3956"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="5118" lat="35.90297366702" lon="139.93297172251">
+    <tag k="local_x" v="3711.8615"/>
+    <tag k="local_y" v="73712.7133"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="5119" lat="35.90297633353" lon="139.93297483378">
+    <tag k="local_x" v="3712.1455"/>
+    <tag k="local_y" v="73713.006"/>
+    <tag k="ele" v="19.291"/>
+  </node>
+  <node id="5120" lat="35.90297872237" lon="139.93297825018">
+    <tag k="local_x" v="3712.4567"/>
+    <tag k="local_y" v="73713.2676"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="5121" lat="35.90298102854" lon="139.93298230598">
+    <tag k="local_x" v="3712.8255"/>
+    <tag k="local_y" v="73713.5194"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="5965" lat="35.90320483422" lon="139.93349313886">
+    <tag k="local_x" v="3759.1955"/>
+    <tag k="local_y" v="73737.8403"/>
+    <tag k="ele" v="19.27"/>
+  </node>
+  <node id="5966" lat="35.90327230582" lon="139.93364883382">
+    <tag k="local_x" v="3773.3275"/>
+    <tag k="local_y" v="73745.1708"/>
+    <tag k="ele" v="19.266"/>
+  </node>
+  <node id="5970" lat="35.90329605614" lon="139.93363305572">
+    <tag k="local_x" v="3771.9324"/>
+    <tag k="local_y" v="73747.8207"/>
+    <tag k="ele" v="19.334"/>
+  </node>
+  <node id="5974" lat="35.90322836152" lon="139.93347783356">
+    <tag k="local_x" v="3757.8428"/>
+    <tag k="local_y" v="73740.465"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="5979" lat="35.90331302853" lon="139.93348511147">
+    <tag k="local_x" v="3758.6021"/>
+    <tag k="local_y" v="73749.849"/>
+    <tag k="ele" v="19.202"/>
+  </node>
+  <node id="5980" lat="35.90330291685" lon="139.93349477814">
+    <tag k="local_x" v="3759.4622"/>
+    <tag k="local_y" v="73748.7179"/>
+    <tag k="ele" v="19.231"/>
+  </node>
+  <node id="5981" lat="35.90329552857" lon="139.93350330569">
+    <tag k="local_x" v="3760.2228"/>
+    <tag k="local_y" v="73747.89"/>
+    <tag k="ele" v="19.257"/>
+  </node>
+  <node id="5982" lat="35.9032884731" lon="139.93351316627">
+    <tag k="local_x" v="3761.1041"/>
+    <tag k="local_y" v="73747.0977"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="5983" lat="35.90328222306" lon="139.93352377733">
+    <tag k="local_x" v="3762.0541"/>
+    <tag k="local_y" v="73746.394"/>
+    <tag k="ele" v="19.311"/>
+  </node>
+  <node id="5984" lat="35.90327683413" lon="139.93353511151">
+    <tag k="local_x" v="3763.0704"/>
+    <tag k="local_y" v="73745.7851"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="5985" lat="35.90327236184" lon="139.93354702736">
+    <tag k="local_x" v="3764.1403"/>
+    <tag k="local_y" v="73745.2773"/>
+    <tag k="ele" v="19.352"/>
+  </node>
+  <node id="5986" lat="35.90326883384" lon="139.93355938929">
+    <tag k="local_x" v="3765.2516"/>
+    <tag k="local_y" v="73744.8738"/>
+    <tag k="ele" v="19.357"/>
+  </node>
+  <node id="5987" lat="35.90326627846" lon="139.93357213932">
+    <tag k="local_x" v="3766.3991"/>
+    <tag k="local_y" v="73744.5778"/>
+    <tag k="ele" v="19.358"/>
+  </node>
+  <node id="5988" lat="35.90326475012" lon="139.9335851116">
+    <tag k="local_x" v="3767.5679"/>
+    <tag k="local_y" v="73744.3955"/>
+    <tag k="ele" v="19.354"/>
+  </node>
+  <node id="5989" lat="35.90326425079" lon="139.93359822188">
+    <tag k="local_x" v="3768.7504"/>
+    <tag k="local_y" v="73744.3272"/>
+    <tag k="ele" v="19.326"/>
+  </node>
+  <node id="5990" lat="35.90326477809" lon="139.93361130509">
+    <tag k="local_x" v="3769.9317"/>
+    <tag k="local_y" v="73744.3728"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="5991" lat="35.90326630604" lon="139.93362427736">
+    <tag k="local_x" v="3771.1042"/>
+    <tag k="local_y" v="73744.5295"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="5992" lat="35.90326877864" lon="139.93363672168">
+    <tag k="local_x" v="3772.2302"/>
+    <tag k="local_y" v="73744.7915"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="5998" lat="35.90329458422" lon="139.9336276113">
+    <tag k="local_x" v="3771.4393"/>
+    <tag k="local_y" v="73747.6628"/>
+    <tag k="ele" v="19.332"/>
+  </node>
+  <node id="5999" lat="35.90329266755" lon="139.93361797194">
+    <tag k="local_x" v="3770.5671"/>
+    <tag k="local_y" v="73747.4597"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="6000" lat="35.90329150015" lon="139.93360813858">
+    <tag k="local_x" v="3769.6783"/>
+    <tag k="local_y" v="73747.3399"/>
+    <tag k="ele" v="19.321"/>
+  </node>
+  <node id="6001" lat="35.90329111187" lon="139.93359822274">
+    <tag k="local_x" v="3768.783"/>
+    <tag k="local_y" v="73747.3066"/>
+    <tag k="ele" v="19.312"/>
+  </node>
+  <node id="6002" lat="35.90329150047" lon="139.93358827763">
+    <tag k="local_x" v="3767.886"/>
+    <tag k="local_y" v="73747.3595"/>
+    <tag k="ele" v="19.315"/>
+  </node>
+  <node id="6003" lat="35.90329263926" lon="139.93357844436">
+    <tag k="local_x" v="3767"/>
+    <tag k="local_y" v="73747.4955"/>
+    <tag k="ele" v="19.316"/>
+  </node>
+  <node id="6004" lat="35.90329458372" lon="139.93356877758">
+    <tag k="local_x" v="3766.13"/>
+    <tag k="local_y" v="73747.7207"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="6005" lat="35.90329725035" lon="139.93355941692">
+    <tag k="local_x" v="3765.2885"/>
+    <tag k="local_y" v="73748.0257"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="6006" lat="35.90330063937" lon="139.93355038898">
+    <tag k="local_x" v="3764.4779"/>
+    <tag k="local_y" v="73748.4105"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="6007" lat="35.90330472294" lon="139.93354180605">
+    <tag k="local_x" v="3763.7083"/>
+    <tag k="local_y" v="73748.8719"/>
+    <tag k="ele" v="19.286"/>
+  </node>
+  <node id="6008" lat="35.90330944498" lon="139.93353374978">
+    <tag k="local_x" v="3762.987"/>
+    <tag k="local_y" v="73749.4036"/>
+    <tag k="ele" v="19.265"/>
+  </node>
+  <node id="6009" lat="35.903314806" lon="139.93352627778">
+    <tag k="local_x" v="3762.3192"/>
+    <tag k="local_y" v="73750.0056"/>
+    <tag k="ele" v="19.242"/>
+  </node>
+  <node id="6010" lat="35.9033206952" lon="139.93351950013">
+    <tag k="local_x" v="3761.7147"/>
+    <tag k="local_y" v="73750.6655"/>
+    <tag k="ele" v="19.219"/>
+  </node>
+  <node id="6011" lat="35.90332600031" lon="139.93351405565">
+    <tag k="local_x" v="3761.2298"/>
+    <tag k="local_y" v="73751.2593"/>
+    <tag k="ele" v="19.204"/>
+  </node>
+  <node id="6016" lat="35.90321169502" lon="139.93362641626">
+    <tag k="local_x" v="3771.2311"/>
+    <tag k="local_y" v="73738.47"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="6017" lat="35.9032203893" lon="139.93362505519">
+    <tag k="local_x" v="3771.1188"/>
+    <tag k="local_y" v="73739.4357"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="6018" lat="35.90322613968" lon="139.93362447274">
+    <tag k="local_x" v="3771.0732"/>
+    <tag k="local_y" v="73740.0741"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="6019" lat="35.90323191672" lon="139.93362455591">
+    <tag k="local_x" v="3771.0877"/>
+    <tag k="local_y" v="73740.7148"/>
+    <tag k="ele" v="19.292"/>
+  </node>
+  <node id="6020" lat="35.90323766721" lon="139.93362530542">
+    <tag k="local_x" v="3771.1623"/>
+    <tag k="local_y" v="73741.3519"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="6021" lat="35.90324333347" lon="139.93362672204">
+    <tag k="local_x" v="3771.297"/>
+    <tag k="local_y" v="73741.979"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="6022" lat="35.90324886165" lon="139.93362883309">
+    <tag k="local_x" v="3771.4942"/>
+    <tag k="local_y" v="73742.5901"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="6023" lat="35.90325422307" lon="139.93363155586">
+    <tag k="local_x" v="3771.7464"/>
+    <tag k="local_y" v="73743.1821"/>
+    <tag k="ele" v="19.281"/>
+  </node>
+  <node id="6024" lat="35.90325930566" lon="139.9336348608">
+    <tag k="local_x" v="3772.0508"/>
+    <tag k="local_y" v="73743.7426"/>
+    <tag k="ele" v="19.277"/>
+  </node>
+  <node id="6025" lat="35.90326413944" lon="139.93363877744">
+    <tag k="local_x" v="3772.4101"/>
+    <tag k="local_y" v="73744.2749"/>
+    <tag k="ele" v="19.272"/>
+  </node>
+  <node id="6026" lat="35.90326863918" lon="139.93364325041">
+    <tag k="local_x" v="3772.8192"/>
+    <tag k="local_y" v="73744.7696"/>
+    <tag k="ele" v="19.267"/>
+  </node>
+  <node id="6032" lat="35.90328763904" lon="139.93361994427">
+    <tag k="local_x" v="3770.739"/>
+    <tag k="local_y" v="73746.9"/>
+    <tag k="ele" v="19.331"/>
+  </node>
+  <node id="6033" lat="35.90327991671" lon="139.9336122777">
+    <tag k="local_x" v="3770.0378"/>
+    <tag k="local_y" v="73746.051"/>
+    <tag k="ele" v="19.324"/>
+  </node>
+  <node id="6034" lat="35.9032729724" lon="139.93360663854">
+    <tag k="local_x" v="3769.5205"/>
+    <tag k="local_y" v="73745.2863"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="6035" lat="35.90326561177" lon="139.93360183384">
+    <tag k="local_x" v="3769.078"/>
+    <tag k="local_y" v="73744.4746"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="6036" lat="35.90325791733" lon="139.93359791679">
+    <tag k="local_x" v="3768.7152"/>
+    <tag k="local_y" v="73743.625"/>
+    <tag k="ele" v="19.324"/>
+  </node>
+  <node id="6037" lat="35.90324994524" lon="139.93359491657">
+    <tag k="local_x" v="3768.4348"/>
+    <tag k="local_y" v="73742.7437"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="6038" lat="35.90324180574" lon="139.93359286161">
+    <tag k="local_x" v="3768.2395"/>
+    <tag k="local_y" v="73741.8429"/>
+    <tag k="ele" v="19.336"/>
+  </node>
+  <node id="6039" lat="35.90323352791" lon="139.93359177811">
+    <tag k="local_x" v="3768.1317"/>
+    <tag k="local_y" v="73740.9258"/>
+    <tag k="ele" v="19.344"/>
+  </node>
+  <node id="6040" lat="35.90322519536" lon="139.93359163837">
+    <tag k="local_x" v="3768.109"/>
+    <tag k="local_y" v="73740.0017"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="6041" lat="35.90321758409" lon="139.93359241644">
+    <tag k="local_x" v="3768.17"/>
+    <tag k="local_y" v="73739.1567"/>
+    <tag k="ele" v="19.321"/>
+  </node>
+  <node id="6042" lat="35.90320825054" lon="139.9335942781">
+    <tag k="local_x" v="3768.3267"/>
+    <tag k="local_y" v="73738.1196"/>
+    <tag k="ele" v="19.302"/>
+  </node>
+  <node id="6043" lat="35.90319913971" lon="139.93359736125">
+    <tag k="local_x" v="3768.5939"/>
+    <tag k="local_y" v="73737.106"/>
+    <tag k="ele" v="19.287"/>
+  </node>
+  <node id="6048" lat="35.90331944534" lon="139.93361752734">
+    <tag k="local_x" v="3770.5594"/>
+    <tag k="local_y" v="73750.4303"/>
+    <tag k="ele" v="19.248"/>
+  </node>
+  <node id="6049" lat="35.90325194536" lon="139.93346249979">
+    <tag k="local_x" v="3756.4876"/>
+    <tag k="local_y" v="73743.096"/>
+    <tag k="ele" v="19.255"/>
+  </node>
+  <node id="6063" lat="35.90331194454" lon="139.93348558367">
+    <tag k="local_x" v="3758.6434"/>
+    <tag k="local_y" v="73749.7283"/>
+    <tag k="ele" v="19.2"/>
+  </node>
+  <node id="6064" lat="35.90330713969" lon="139.93348736131">
+    <tag k="local_x" v="3758.798"/>
+    <tag k="local_y" v="73749.1936"/>
+    <tag k="ele" v="19.212"/>
+  </node>
+  <node id="6065" lat="35.90330222237" lon="139.93348855536">
+    <tag k="local_x" v="3758.8998"/>
+    <tag k="local_y" v="73748.647"/>
+    <tag k="ele" v="19.222"/>
+  </node>
+  <node id="6066" lat="35.903297223" lon="139.93348913883">
+    <tag k="local_x" v="3758.9464"/>
+    <tag k="local_y" v="73748.0919"/>
+    <tag k="ele" v="19.231"/>
+  </node>
+  <node id="6067" lat="35.9032922223" lon="139.93348916715">
+    <tag k="local_x" v="3758.9429"/>
+    <tag k="local_y" v="73747.5372"/>
+    <tag k="ele" v="19.24"/>
+  </node>
+  <node id="6068" lat="35.90328722247" lon="139.93348858377">
+    <tag k="local_x" v="3758.8842"/>
+    <tag k="local_y" v="73746.9832"/>
+    <tag k="ele" v="19.247"/>
+  </node>
+  <node id="6069" lat="35.90328230582" lon="139.93348741639">
+    <tag k="local_x" v="3758.7729"/>
+    <tag k="local_y" v="73746.439"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="6070" lat="35.90327750029" lon="139.93348566688">
+    <tag k="local_x" v="3758.6092"/>
+    <tag k="local_y" v="73745.9077"/>
+    <tag k="ele" v="19.257"/>
+  </node>
+  <node id="6071" lat="35.90327286177" lon="139.93348333335">
+    <tag k="local_x" v="3758.393"/>
+    <tag k="local_y" v="73745.3955"/>
+    <tag k="ele" v="19.259"/>
+  </node>
+  <node id="6072" lat="35.90326841716" lon="139.93348049967">
+    <tag k="local_x" v="3758.1319"/>
+    <tag k="local_y" v="73744.9053"/>
+    <tag k="ele" v="19.26"/>
+  </node>
+  <node id="6073" lat="35.903264223" lon="139.93347713849">
+    <tag k="local_x" v="3757.8235"/>
+    <tag k="local_y" v="73744.4434"/>
+    <tag k="ele" v="19.26"/>
+  </node>
+  <node id="6074" lat="35.90326030594" lon="139.93347330596">
+    <tag k="local_x" v="3757.4729"/>
+    <tag k="local_y" v="73744.0127"/>
+    <tag k="ele" v="19.259"/>
+  </node>
+  <node id="6075" lat="35.90325669481" lon="139.93346899949">
+    <tag k="local_x" v="3757.0799"/>
+    <tag k="local_y" v="73743.6164"/>
+    <tag k="ele" v="19.256"/>
+  </node>
+  <node id="6076" lat="35.90325413895" lon="139.93346555538">
+    <tag k="local_x" v="3756.766"/>
+    <tag k="local_y" v="73743.3363"/>
+    <tag k="ele" v="19.254"/>
+  </node>
+  <node id="6082" lat="35.90323213942" lon="139.93348447262">
+    <tag k="local_x" v="3758.4465"/>
+    <tag k="local_y" v="73740.8775"/>
+    <tag k="ele" v="19.334"/>
+  </node>
+  <node id="6083" lat="35.90323708363" lon="139.9334915836">
+    <tag k="local_x" v="3759.0942"/>
+    <tag k="local_y" v="73741.4189"/>
+    <tag k="ele" v="19.332"/>
+  </node>
+  <node id="6084" lat="35.90324252817" lon="139.93349808284">
+    <tag k="local_x" v="3759.6873"/>
+    <tag k="local_y" v="73742.0164"/>
+    <tag k="ele" v="19.333"/>
+  </node>
+  <node id="6085" lat="35.90324847259" lon="139.93350391714">
+    <tag k="local_x" v="3760.221"/>
+    <tag k="local_y" v="73742.67"/>
+    <tag k="ele" v="19.333"/>
+  </node>
+  <node id="6086" lat="35.90325486135" lon="139.93350902741">
+    <tag k="local_x" v="3760.6899"/>
+    <tag k="local_y" v="73743.3736"/>
+    <tag k="ele" v="19.331"/>
+  </node>
+  <node id="6087" lat="35.90326158375" lon="139.93351333315">
+    <tag k="local_x" v="3761.0866"/>
+    <tag k="local_y" v="73744.115"/>
+    <tag k="ele" v="19.327"/>
+  </node>
+  <node id="6088" lat="35.9032686398" lon="139.93351683323">
+    <tag k="local_x" v="3761.411"/>
+    <tag k="local_y" v="73744.8942"/>
+    <tag k="ele" v="19.321"/>
+  </node>
+  <node id="6089" lat="35.90327594448" lon="139.93351949999">
+    <tag k="local_x" v="3761.6605"/>
+    <tag k="local_y" v="73745.7018"/>
+    <tag k="ele" v="19.315"/>
+  </node>
+  <node id="6090" lat="35.90328338912" lon="139.93352127726">
+    <tag k="local_x" v="3761.8299"/>
+    <tag k="local_y" v="73746.5258"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="6091" lat="35.90329097282" lon="139.93352216617">
+    <tag k="local_x" v="3761.9193"/>
+    <tag k="local_y" v="73747.3661"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="6092" lat="35.90329858355" lon="139.9335221394">
+    <tag k="local_x" v="3761.9261"/>
+    <tag k="local_y" v="73748.2103"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="6093" lat="35.90330613949" lon="139.93352122244">
+    <tag k="local_x" v="3761.8525"/>
+    <tag k="local_y" v="73749.0493"/>
+    <tag k="ele" v="19.258"/>
+  </node>
+  <node id="6094" lat="35.90331361181" lon="139.93351941677">
+    <tag k="local_x" v="3761.6986"/>
+    <tag k="local_y" v="73749.8799"/>
+    <tag k="ele" v="19.237"/>
+  </node>
+  <node id="6095" lat="35.90332088896" lon="139.93351675049">
+    <tag k="local_x" v="3761.4668"/>
+    <tag k="local_y" v="73750.6897"/>
+    <tag k="ele" v="19.215"/>
+  </node>
+  <node id="6102" lat="35.90321427858" lon="139.93362394483">
+    <tag k="local_x" v="3771.0112"/>
+    <tag k="local_y" v="73738.759"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="6103" lat="35.9032220007" lon="139.93361605554">
+    <tag k="local_x" v="3770.3086"/>
+    <tag k="local_y" v="73739.6233"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="6104" lat="35.90322938963" lon="139.93360719447">
+    <tag k="local_x" v="3769.5179"/>
+    <tag k="local_y" v="73740.4516"/>
+    <tag k="ele" v="19.318"/>
+  </node>
+  <node id="6105" lat="35.9032360558" lon="139.93359755521">
+    <tag k="local_x" v="3768.6561"/>
+    <tag k="local_y" v="73741.2005"/>
+    <tag k="ele" v="19.331"/>
+  </node>
+  <node id="6106" lat="35.90324200038" lon="139.93358716656">
+    <tag k="local_x" v="3767.7258"/>
+    <tag k="local_y" v="73741.8701"/>
+    <tag k="ele" v="19.347"/>
+  </node>
+  <node id="6107" lat="35.90324708371" lon="139.933576139">
+    <tag k="local_x" v="3766.7368"/>
+    <tag k="local_y" v="73742.4448"/>
+    <tag k="ele" v="19.369"/>
+  </node>
+  <node id="6108" lat="35.90325133381" lon="139.93356458296">
+    <tag k="local_x" v="3765.6991"/>
+    <tag k="local_y" v="73742.9276"/>
+    <tag k="ele" v="19.371"/>
+  </node>
+  <node id="6109" lat="35.90325466759" lon="139.93355258377">
+    <tag k="local_x" v="3764.6203"/>
+    <tag k="local_y" v="73743.3092"/>
+    <tag k="ele" v="19.373"/>
+  </node>
+  <node id="6110" lat="35.90325708422" lon="139.93354025005">
+    <tag k="local_x" v="3763.5102"/>
+    <tag k="local_y" v="73743.5894"/>
+    <tag k="ele" v="19.373"/>
+  </node>
+  <node id="6111" lat="35.90325855584" lon="139.93352769408">
+    <tag k="local_x" v="3762.3789"/>
+    <tag k="local_y" v="73743.765"/>
+    <tag k="ele" v="19.353"/>
+  </node>
+  <node id="6112" lat="35.90325902846" lon="139.93351502741">
+    <tag k="local_x" v="3761.2364"/>
+    <tag k="local_y" v="73743.8299"/>
+    <tag k="ele" v="19.333"/>
+  </node>
+  <node id="6113" lat="35.90325858418" lon="139.93350236084">
+    <tag k="local_x" v="3760.0928"/>
+    <tag k="local_y" v="73743.7931"/>
+    <tag k="ele" v="19.315"/>
+  </node>
+  <node id="6114" lat="35.90325713926" lon="139.93348980523">
+    <tag k="local_x" v="3758.958"/>
+    <tag k="local_y" v="73743.6452"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="6115" lat="35.90325475057" lon="139.93347747171">
+    <tag k="local_x" v="3757.8421"/>
+    <tag k="local_y" v="73743.3924"/>
+    <tag k="ele" v="19.275"/>
+  </node>
+  <node id="6121" lat="35.9032298617" lon="139.93348280554">
+    <tag k="local_x" v="3758.2933"/>
+    <tag k="local_y" v="73740.6265"/>
+    <tag k="ele" v="19.335"/>
+  </node>
+  <node id="6122" lat="35.90323191737" lon="139.93349205517">
+    <tag k="local_x" v="3759.1305"/>
+    <tag k="local_y" v="73740.8454"/>
+    <tag k="ele" v="19.331"/>
+  </node>
+  <node id="6123" lat="35.90323325016" lon="139.93350152727">
+    <tag k="local_x" v="3759.9869"/>
+    <tag k="local_y" v="73740.9839"/>
+    <tag k="ele" v="19.336"/>
+  </node>
+  <node id="6124" lat="35.90323386179" lon="139.933511111">
+    <tag k="local_x" v="3760.8525"/>
+    <tag k="local_y" v="73741.0423"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="6125" lat="35.90323375061" lon="139.93352072215">
+    <tag k="local_x" v="3761.7197"/>
+    <tag k="local_y" v="73741.0205"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="6126" lat="35.90323288975" lon="139.93353027798">
+    <tag k="local_x" v="3762.581"/>
+    <tag k="local_y" v="73740.9156"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="6127" lat="35.90323130639" lon="139.93353969391">
+    <tag k="local_x" v="3763.4288"/>
+    <tag k="local_y" v="73740.7307"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="6128" lat="35.90322900073" lon="139.93354888904">
+    <tag k="local_x" v="3764.2558"/>
+    <tag k="local_y" v="73740.4659"/>
+    <tag k="ele" v="19.34"/>
+  </node>
+  <node id="6129" lat="35.90322602789" lon="139.93355777731">
+    <tag k="local_x" v="3765.0543"/>
+    <tag k="local_y" v="73740.1274"/>
+    <tag k="ele" v="19.343"/>
+  </node>
+  <node id="6130" lat="35.90322236167" lon="139.93356625046">
+    <tag k="local_x" v="3765.8145"/>
+    <tag k="local_y" v="73739.7124"/>
+    <tag k="ele" v="19.344"/>
+  </node>
+  <node id="6131" lat="35.90321808408" lon="139.93357430519">
+    <tag k="local_x" v="3766.5362"/>
+    <tag k="local_y" v="73739.23"/>
+    <tag k="ele" v="19.335"/>
+  </node>
+  <node id="6132" lat="35.90321316687" lon="139.93358180558">
+    <tag k="local_x" v="3767.2071"/>
+    <tag k="local_y" v="73738.6772"/>
+    <tag k="ele" v="19.32"/>
+  </node>
+  <node id="6133" lat="35.90320775042" lon="139.93358872203">
+    <tag k="local_x" v="3767.8247"/>
+    <tag k="local_y" v="73738.0696"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="6134" lat="35.90320180604" lon="139.93359497182">
+    <tag k="local_x" v="3768.3815"/>
+    <tag k="local_y" v="73737.4041"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="6141" lat="35.9031865562" lon="139.93356827781">
+    <tag k="local_x" v="3765.9541"/>
+    <tag k="local_y" v="73735.7389"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="6154" lat="35.90330644474" lon="139.93359711057">
+    <tag k="local_x" v="3768.7012"/>
+    <tag k="local_y" v="73749.0084"/>
+    <tag k="ele" v="19.279"/>
+  </node>
+  <node id="6155" lat="35.90329541728" lon="139.93358619389">
+    <tag k="local_x" v="3767.7027"/>
+    <tag k="local_y" v="73747.796"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="6156" lat="35.90328638974" lon="139.93357886065">
+    <tag k="local_x" v="3767.03"/>
+    <tag k="local_y" v="73746.8019"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="6157" lat="35.90327683361" lon="139.9335726116">
+    <tag k="local_x" v="3766.4545"/>
+    <tag k="local_y" v="73745.7481"/>
+    <tag k="ele" v="19.345"/>
+  </node>
+  <node id="6158" lat="35.90326683409" lon="139.9335674999">
+    <tag k="local_x" v="3765.9811"/>
+    <tag k="local_y" v="73744.644"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="6159" lat="35.90325647308" lon="139.93356361088">
+    <tag k="local_x" v="3765.6176"/>
+    <tag k="local_y" v="73743.4986"/>
+    <tag k="ele" v="19.368"/>
+  </node>
+  <node id="6160" lat="35.90324586123" lon="139.93356091646">
+    <tag k="local_x" v="3765.3616"/>
+    <tag k="local_y" v="73742.3242"/>
+    <tag k="ele" v="19.376"/>
+  </node>
+  <node id="6161" lat="35.90323508403" lon="139.93355949972">
+    <tag k="local_x" v="3765.2207"/>
+    <tag k="local_y" v="73741.1302"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="6162" lat="35.90322425031" lon="139.93355933369">
+    <tag k="local_x" v="3765.1926"/>
+    <tag k="local_y" v="73739.9287"/>
+    <tag k="ele" v="19.342"/>
+  </node>
+  <node id="6163" lat="35.90321441686" lon="139.93356033329">
+    <tag k="local_x" v="3765.2709"/>
+    <tag k="local_y" v="73738.837"/>
+    <tag k="ele" v="19.325"/>
+  </node>
+  <node id="6164" lat="35.90320263912" lon="139.93356269427">
+    <tag k="local_x" v="3765.4697"/>
+    <tag k="local_y" v="73737.5283"/>
+    <tag k="ele" v="19.307"/>
+  </node>
+  <node id="6187" lat="35.90320572284" lon="139.93349624963">
+    <tag k="local_x" v="3759.4773"/>
+    <tag k="local_y" v="73737.9358"/>
+    <tag k="ele" v="19.271"/>
+  </node>
+  <node id="6188" lat="35.90320702831" lon="139.93350213842">
+    <tag k="local_x" v="3760.0103"/>
+    <tag k="local_y" v="73738.0748"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="6189" lat="35.90320788915" lon="139.93350811074">
+    <tag k="local_x" v="3760.5503"/>
+    <tag k="local_y" v="73738.1644"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="6190" lat="35.90320827857" lon="139.93351419466">
+    <tag k="local_x" v="3761.0998"/>
+    <tag k="local_y" v="73738.2016"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="6191" lat="35.90320819466" lon="139.93352027829">
+    <tag k="local_x" v="3761.6487"/>
+    <tag k="local_y" v="73738.1863"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="6192" lat="35.90320763898" lon="139.93352633278">
+    <tag k="local_x" v="3762.1944"/>
+    <tag k="local_y" v="73738.1187"/>
+    <tag k="ele" v="19.291"/>
+  </node>
+  <node id="6193" lat="35.90320663901" lon="139.93353230569">
+    <tag k="local_x" v="3762.7322"/>
+    <tag k="local_y" v="73738.0019"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="6194" lat="35.90320519488" lon="139.93353811059">
+    <tag k="local_x" v="3763.2543"/>
+    <tag k="local_y" v="73737.836"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="6195" lat="35.90320330571" lon="139.93354374969">
+    <tag k="local_x" v="3763.7609"/>
+    <tag k="local_y" v="73737.6209"/>
+    <tag k="ele" v="19.295"/>
+  </node>
+  <node id="6196" lat="35.90320097231" lon="139.93354911108">
+    <tag k="local_x" v="3764.2419"/>
+    <tag k="local_y" v="73737.3568"/>
+    <tag k="ele" v="19.294"/>
+  </node>
+  <node id="6197" lat="35.90319825081" lon="139.9335542217">
+    <tag k="local_x" v="3764.6998"/>
+    <tag k="local_y" v="73737.0499"/>
+    <tag k="ele" v="19.293"/>
+  </node>
+  <node id="6198" lat="35.90319516729" lon="139.9335589726">
+    <tag k="local_x" v="3765.1248"/>
+    <tag k="local_y" v="73736.7032"/>
+    <tag k="ele" v="19.29"/>
+  </node>
+  <node id="6199" lat="35.9031917224" lon="139.93356333386">
+    <tag k="local_x" v="3765.5142"/>
+    <tag k="local_y" v="73736.3168"/>
+    <tag k="ele" v="19.288"/>
+  </node>
+  <node id="6225" lat="35.90333894503" lon="139.93354300019">
+    <tag k="local_x" v="3763.8575"/>
+    <tag k="local_y" v="73752.6666"/>
+    <tag k="ele" v="19.207"/>
+  </node>
+  <node id="6238" lat="35.90331869507" lon="139.93361172196">
+    <tag k="local_x" v="3770.0346"/>
+    <tag k="local_y" v="73750.3528"/>
+    <tag k="ele" v="19.247"/>
+  </node>
+  <node id="6239" lat="35.90331788978" lon="139.93360499979">
+    <tag k="local_x" v="3769.427"/>
+    <tag k="local_y" v="73750.2701"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="6240" lat="35.90331761116" lon="139.9335981941">
+    <tag k="local_x" v="3768.8125"/>
+    <tag k="local_y" v="73750.2459"/>
+    <tag k="ele" v="19.252"/>
+  </node>
+  <node id="6241" lat="35.90331788971" lon="139.93359138868">
+    <tag k="local_x" v="3768.1987"/>
+    <tag k="local_y" v="73750.2835"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="6242" lat="35.90331866756" lon="139.93358466632">
+    <tag k="local_x" v="3767.593"/>
+    <tag k="local_y" v="73750.3764"/>
+    <tag k="ele" v="19.253"/>
+  </node>
+  <node id="6243" lat="35.90332000085" lon="139.93357805508">
+    <tag k="local_x" v="3766.998"/>
+    <tag k="local_y" v="73750.5308"/>
+    <tag k="ele" v="19.251"/>
+  </node>
+  <node id="6244" lat="35.90332183354" lon="139.93357163882">
+    <tag k="local_x" v="3766.4212"/>
+    <tag k="local_y" v="73750.7404"/>
+    <tag k="ele" v="19.247"/>
+  </node>
+  <node id="6245" lat="35.90332413905" lon="139.93356547219">
+    <tag k="local_x" v="3765.8675"/>
+    <tag k="local_y" v="73751.0022"/>
+    <tag k="ele" v="19.242"/>
+  </node>
+  <node id="6246" lat="35.9033269447" lon="139.93355958364">
+    <tag k="local_x" v="3765.3395"/>
+    <tag k="local_y" v="73751.3192"/>
+    <tag k="ele" v="19.235"/>
+  </node>
+  <node id="6247" lat="35.90333019466" lon="139.93355408362">
+    <tag k="local_x" v="3764.8471"/>
+    <tag k="local_y" v="73751.6851"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="6248" lat="35.90333383393" lon="139.93354897176">
+    <tag k="local_x" v="3764.3902"/>
+    <tag k="local_y" v="73752.0938"/>
+    <tag k="ele" v="19.218"/>
+  </node>
+  <node id="6273" lat="35.90321094526" lon="139.93350463898">
+    <tag k="local_x" v="3760.2407"/>
+    <tag k="local_y" v="73738.5068"/>
+    <tag k="ele" v="19.285"/>
+  </node>
+  <node id="6274" lat="35.90321750013" lon="139.93351413853">
+    <tag k="local_x" v="3761.1059"/>
+    <tag k="local_y" v="73739.2245"/>
+    <tag k="ele" v="19.303"/>
+  </node>
+  <node id="6275" lat="35.90322480631" lon="139.93352286117">
+    <tag k="local_x" v="3761.9019"/>
+    <tag k="local_y" v="73740.0263"/>
+    <tag k="ele" v="19.322"/>
+  </node>
+  <node id="6276" lat="35.9032327787" lon="139.93353066621">
+    <tag k="local_x" v="3762.6159"/>
+    <tag k="local_y" v="73740.9029"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="6277" lat="35.90324130594" lon="139.93353749974">
+    <tag k="local_x" v="3763.2429"/>
+    <tag k="local_y" v="73741.842"/>
+    <tag k="ele" v="19.353"/>
+  </node>
+  <node id="6278" lat="35.90325033409" lon="139.93354327826">
+    <tag k="local_x" v="3763.7753"/>
+    <tag k="local_y" v="73742.8377"/>
+    <tag k="ele" v="19.369"/>
+  </node>
+  <node id="6279" lat="35.9032598061" lon="139.93354797262">
+    <tag k="local_x" v="3764.2104"/>
+    <tag k="local_y" v="73743.8837"/>
+    <tag k="ele" v="19.371"/>
+  </node>
+  <node id="6280" lat="35.90326955649" lon="139.93355152742">
+    <tag k="local_x" v="3764.543"/>
+    <tag k="local_y" v="73744.9617"/>
+    <tag k="ele" v="19.356"/>
+  </node>
+  <node id="6281" lat="35.90327958412" lon="139.93355391719">
+    <tag k="local_x" v="3764.7708"/>
+    <tag k="local_y" v="73746.0716"/>
+    <tag k="ele" v="19.341"/>
+  </node>
+  <node id="6282" lat="35.90328972285" lon="139.9335551109">
+    <tag k="local_x" v="3764.8908"/>
+    <tag k="local_y" v="73747.195"/>
+    <tag k="ele" v="19.323"/>
+  </node>
+  <node id="6283" lat="35.90329991744" lon="139.93355508382">
+    <tag k="local_x" v="3764.9007"/>
+    <tag k="local_y" v="73748.3258"/>
+    <tag k="ele" v="19.3"/>
+  </node>
+  <node id="6284" lat="35.90331005634" lon="139.93355386071">
+    <tag k="local_x" v="3764.8026"/>
+    <tag k="local_y" v="73749.4516"/>
+    <tag k="ele" v="19.276"/>
+  </node>
+  <node id="6285" lat="35.90332005572" lon="139.93355144491">
+    <tag k="local_x" v="3764.5967"/>
+    <tag k="local_y" v="73750.5631"/>
+    <tag k="ele" v="19.252"/>
+  </node>
+  <node id="6286" lat="35.90333000071" lon="139.93354777766">
+    <tag k="local_x" v="3764.2778"/>
+    <tag k="local_y" v="73751.6698"/>
+    <tag k="ele" v="19.227"/>
+  </node>
+  <node id="8790" lat="35.90291563896" lon="139.93295325014">
+    <tag k="local_x" v="3710.1242"/>
+    <tag k="local_y" v="73706.2951"/>
+    <tag k="ele" v="25.097"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8791" lat="35.90295188894" lon="139.93286641648">
+    <tag k="local_x" v="3702.332"/>
+    <tag k="local_y" v="73710.4015"/>
+    <tag k="ele" v="24.91"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8792" lat="35.9030380564" lon="139.93284044431">
+    <tag k="local_x" v="3700.0926"/>
+    <tag k="local_y" v="73719.9847"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8793" lat="35.90322041715" lon="139.93345958297">
+    <tag k="local_x" v="3756.1862"/>
+    <tag k="local_y" v="73739.6018"/>
+    <tag k="ele" v="25.18"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8794" lat="35.90334572241" lon="139.93351908343">
+    <tag k="local_x" v="3761.7074"/>
+    <tag k="local_y" v="73753.4419"/>
+    <tag k="ele" v="25.052"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8795" lat="35.90330397284" lon="139.93365083355">
+    <tag k="local_x" v="3773.5463"/>
+    <tag k="local_y" v="73748.6813"/>
+    <tag k="ele" v="25.006"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8796" lat="35.9031960557" lon="139.93361911079">
+    <tag k="local_x" v="3770.5529"/>
+    <tag k="local_y" v="73736.7425"/>
+    <tag k="ele" v="25.033"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8797" lat="35.90317852808" lon="139.93359449958">
+    <tag k="local_x" v="3768.3107"/>
+    <tag k="local_y" v="73734.8226"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8798" lat="35.90332677808" lon="139.93349402802">
+    <tag k="local_x" v="3759.4234"/>
+    <tag k="local_y" v="73751.3653"/>
+    <tag k="ele" v="25.076"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8799" lat="35.9032114453" lon="139.93347516613">
+    <tag k="local_x" v="3757.5816"/>
+    <tag k="local_y" v="73738.5913"/>
+    <tag k="ele" v="25.2"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8800" lat="35.90331183416" lon="139.93363547251">
+    <tag k="local_x" v="3772.1696"/>
+    <tag k="local_y" v="73749.5684"/>
+    <tag k="ele" v="25.019"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8801" lat="35.90316636182" lon="139.93357341675">
+    <tag k="local_x" v="3766.3934"/>
+    <tag k="local_y" v="73733.4939"/>
+    <tag k="ele" v="22.312"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8802" lat="35.90335705627" lon="139.93353922226">
+    <tag k="local_x" v="3763.5385"/>
+    <tag k="local_y" v="73754.6792"/>
+    <tag k="ele" v="22.173"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8803" lat="35.90327527854" lon="139.93367536125">
+    <tag k="local_x" v="3775.725"/>
+    <tag k="local_y" v="73745.4744"/>
+    <tag k="ele" v="22.17"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8804" lat="35.90324747279" lon="139.93343763918">
+    <tag k="local_x" v="3754.2387"/>
+    <tag k="local_y" v="73742.6244"/>
+    <tag k="ele" v="22.246"/>
+    <tag k="color" v="yellow"/>
+  </node>
+  <node id="8808" lat="35.90291741689" lon="139.93295711134">
+    <tag k="local_x" v="3710.4748"/>
+    <tag k="local_y" v="73706.4885"/>
+    <tag k="ele" v="25.097"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8809" lat="35.9029487225" lon="139.93286852785">
+    <tag k="local_x" v="3702.5187"/>
+    <tag k="local_y" v="73710.0482"/>
+    <tag k="ele" v="24.91"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8810" lat="35.90303619511" lon="139.93283663852">
+    <tag k="local_x" v="3699.7469"/>
+    <tag k="local_y" v="73719.782"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8811" lat="35.90322363919" lon="139.9334576393">
+    <tag k="local_x" v="3756.0147"/>
+    <tag k="local_y" v="73739.9611"/>
+    <tag k="ele" v="25.18"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8812" lat="35.90334747262" lon="139.93352297274">
+    <tag k="local_x" v="3762.0605"/>
+    <tag k="local_y" v="73753.6322"/>
+    <tag k="ele" v="25.052"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8813" lat="35.90330080638" lon="139.9336529449">
+    <tag k="local_x" v="3773.733"/>
+    <tag k="local_y" v="73748.328"/>
+    <tag k="ele" v="25.006"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8814" lat="35.90319786131" lon="139.93362294394">
+    <tag k="local_x" v="3770.901"/>
+    <tag k="local_y" v="73736.939"/>
+    <tag k="ele" v="25.033"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8815" lat="35.90317686148" lon="139.93359058367">
+    <tag k="local_x" v="3767.9553"/>
+    <tag k="local_y" v="73734.6416"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8816" lat="35.90332508352" lon="139.93349011136">
+    <tag k="local_x" v="3759.0679"/>
+    <tag k="local_y" v="73751.1812"/>
+    <tag k="ele" v="25.076"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8817" lat="35.90320825065" lon="139.93347725016">
+    <tag k="local_x" v="3757.7658"/>
+    <tag k="local_y" v="73738.2349"/>
+    <tag k="ele" v="25.2"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8818" lat="35.90331500087" lon="139.93363338885">
+    <tag k="local_x" v="3771.9854"/>
+    <tag k="local_y" v="73749.9217"/>
+    <tag k="ele" v="25.019"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8819" lat="35.90316636182" lon="139.93357341675">
+    <tag k="local_x" v="3766.3934"/>
+    <tag k="local_y" v="73733.4939"/>
+    <tag k="ele" v="21.977"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8820" lat="35.90335705627" lon="139.93353922226">
+    <tag k="local_x" v="3763.5385"/>
+    <tag k="local_y" v="73754.6792"/>
+    <tag k="ele" v="21.838"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8821" lat="35.90327527854" lon="139.93367536125">
+    <tag k="local_x" v="3775.725"/>
+    <tag k="local_y" v="73745.4744"/>
+    <tag k="ele" v="21.835"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8822" lat="35.90324747279" lon="139.93343763918">
+    <tag k="local_x" v="3754.2387"/>
+    <tag k="local_y" v="73742.6244"/>
+    <tag k="ele" v="21.911"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8826" lat="35.90291386193" lon="139.93294938892">
+    <tag k="local_x" v="3709.7736"/>
+    <tag k="local_y" v="73706.1018"/>
+    <tag k="ele" v="25.097"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8827" lat="35.90295505629" lon="139.93286430509">
+    <tag k="local_x" v="3702.1453"/>
+    <tag k="local_y" v="73710.7549"/>
+    <tag k="ele" v="24.91"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8828" lat="35.90303988948" lon="139.93284422167">
+    <tag k="local_x" v="3700.4357"/>
+    <tag k="local_y" v="73720.1843"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8829" lat="35.90321719537" lon="139.93346155544">
+    <tag k="local_x" v="3756.3603"/>
+    <tag k="local_y" v="73739.2425"/>
+    <tag k="ele" v="25.18"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8830" lat="35.90334400015" lon="139.93351519485">
+    <tag k="local_x" v="3761.3544"/>
+    <tag k="local_y" v="73753.2547"/>
+    <tag k="ele" v="25.052"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8831" lat="35.90330713905" lon="139.9336486945">
+    <tag k="local_x" v="3773.3571"/>
+    <tag k="local_y" v="73749.0346"/>
+    <tag k="ele" v="25.006"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8832" lat="35.90319425009" lon="139.93361527763">
+    <tag k="local_x" v="3770.2048"/>
+    <tag k="local_y" v="73736.546"/>
+    <tag k="ele" v="25.033"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8833" lat="35.90318022264" lon="139.93359841623">
+    <tag k="local_x" v="3768.6662"/>
+    <tag k="local_y" v="73735.0067"/>
+    <tag k="ele" v="25.034"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8834" lat="35.90332847264" lon="139.93349794467">
+    <tag k="local_x" v="3759.7789"/>
+    <tag k="local_y" v="73751.5494"/>
+    <tag k="ele" v="25.076"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8835" lat="35.90321461202" lon="139.93347308358">
+    <tag k="local_x" v="3757.3975"/>
+    <tag k="local_y" v="73738.9446"/>
+    <tag k="ele" v="25.2"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8836" lat="35.9033086395" lon="139.93363755543">
+    <tag k="local_x" v="3772.3537"/>
+    <tag k="local_y" v="73749.212"/>
+    <tag k="ele" v="25.019"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8837" lat="35.90316636182" lon="139.93357341675">
+    <tag k="local_x" v="3766.3934"/>
+    <tag k="local_y" v="73733.4939"/>
+    <tag k="ele" v="22.647"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8838" lat="35.90335705627" lon="139.93353922226">
+    <tag k="local_x" v="3763.5385"/>
+    <tag k="local_y" v="73754.6792"/>
+    <tag k="ele" v="22.508"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8839" lat="35.90327527854" lon="139.93367536125">
+    <tag k="local_x" v="3775.725"/>
+    <tag k="local_y" v="73745.4744"/>
+    <tag k="ele" v="22.505"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8840" lat="35.90324747279" lon="139.93343763918">
+    <tag k="local_x" v="3754.2387"/>
+    <tag k="local_y" v="73742.6244"/>
+    <tag k="ele" v="22.581"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8841" lat="35.90318000049" lon="139.93352213926">
+    <tag k="local_x" v="3761.7825"/>
+    <tag k="local_y" v="73735.0572"/>
+    <tag k="ele" v="22.522"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8842" lat="35.90319150024" lon="139.93349325018">
+    <tag k="local_x" v="3759.1894"/>
+    <tag k="local_y" v="73736.3612"/>
+    <tag k="ele" v="22.361"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8843" lat="35.9032881114" lon="139.93345569485">
+    <tag k="local_x" v="3755.9173"/>
+    <tag k="local_y" v="73747.1142"/>
+    <tag k="ele" v="22.512"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8844" lat="35.90331072289" lon="139.93347086088">
+    <tag k="local_x" v="3757.3133"/>
+    <tag k="local_y" v="73749.6073"/>
+    <tag k="ele" v="22.401"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8845" lat="35.90334363901" lon="139.9335888336">
+    <tag k="local_x" v="3767.9993"/>
+    <tag k="local_y" v="73753.1421"/>
+    <tag k="ele" v="22.436"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8846" lat="35.90333111149" lon="139.93361630591">
+    <tag k="local_x" v="3770.4633"/>
+    <tag k="local_y" v="73751.7255"/>
+    <tag k="ele" v="22.37"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8847" lat="35.9032341674" lon="139.93365799995">
+    <tag k="local_x" v="3774.1085"/>
+    <tag k="local_y" v="73740.9315"/>
+    <tag k="ele" v="22.507"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8848" lat="35.90321163919" lon="139.93364266655">
+    <tag k="local_x" v="3772.6975"/>
+    <tag k="local_y" v="73738.4478"/>
+    <tag k="ele" v="22.38"/>
+    <tag k="color" v="green"/>
+  </node>
+  <node id="8849" lat="35.90318000049" lon="139.93352213926">
+    <tag k="local_x" v="3761.7825"/>
+    <tag k="local_y" v="73735.0572"/>
+    <tag k="ele" v="22.862"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8850" lat="35.90319150024" lon="139.93349325018">
+    <tag k="local_x" v="3759.1894"/>
+    <tag k="local_y" v="73736.3612"/>
+    <tag k="ele" v="22.701"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8851" lat="35.9032881114" lon="139.93345569485">
+    <tag k="local_x" v="3755.9173"/>
+    <tag k="local_y" v="73747.1142"/>
+    <tag k="ele" v="22.852"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8852" lat="35.90331072289" lon="139.93347086088">
+    <tag k="local_x" v="3757.3133"/>
+    <tag k="local_y" v="73749.6073"/>
+    <tag k="ele" v="22.741"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8853" lat="35.90334363901" lon="139.9335888336">
+    <tag k="local_x" v="3767.9993"/>
+    <tag k="local_y" v="73753.1421"/>
+    <tag k="ele" v="22.776"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8854" lat="35.90333111149" lon="139.93361630591">
+    <tag k="local_x" v="3770.4633"/>
+    <tag k="local_y" v="73751.7255"/>
+    <tag k="ele" v="22.71"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8855" lat="35.9032341674" lon="139.93365799995">
+    <tag k="local_x" v="3774.1085"/>
+    <tag k="local_y" v="73740.9315"/>
+    <tag k="ele" v="22.847"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8856" lat="35.90321163919" lon="139.93364266655">
+    <tag k="local_x" v="3772.6975"/>
+    <tag k="local_y" v="73738.4478"/>
+    <tag k="ele" v="22.72"/>
+    <tag k="color" v="red"/>
+  </node>
+  <node id="8897" lat="35.90329903558" lon="139.93365414771">
+    <tag k="local_x" v="3773.8394"/>
+    <tag k="local_y" v="73748.1304"/>
+    <tag k="ele" v="24.781"/>
+  </node>
+  <node id="8898" lat="35.90330891893" lon="139.93364749822">
+    <tag k="local_x" v="3773.2513"/>
+    <tag k="local_y" v="73749.2332"/>
+    <tag k="ele" v="24.781"/>
+  </node>
+  <node id="8899" lat="35.90320648251" lon="139.93347844739">
+    <tag k="local_x" v="3757.8717"/>
+    <tag k="local_y" v="73738.0376"/>
+    <tag k="ele" v="24.975"/>
+  </node>
+  <node id="8900" lat="35.90321640541" lon="139.93347188712">
+    <tag k="local_x" v="3757.2917"/>
+    <tag k="local_y" v="73739.1447"/>
+    <tag k="ele" v="24.975"/>
+  </node>
+  <node id="8901" lat="35.90327440153" lon="139.93367761808">
+    <tag k="local_x" v="3775.9276"/>
+    <tag k="local_y" v="73745.3749"/>
+    <tag k="ele" v="21.545"/>
+  </node>
+  <node id="8902" lat="35.90327613034" lon="139.93367310809">
+    <tag k="local_x" v="3775.5227"/>
+    <tag k="local_y" v="73745.5711"/>
+    <tag k="ele" v="21.545"/>
+  </node>
+  <node id="8903" lat="35.9032350322" lon="139.93366025668">
+    <tag k="local_x" v="3774.3132"/>
+    <tag k="local_y" v="73741.0252"/>
+    <tag k="ele" v="22.252"/>
+  </node>
+  <node id="8904" lat="35.90323332775" lon="139.93365573291">
+    <tag k="local_x" v="3773.9029"/>
+    <tag k="local_y" v="73740.8406"/>
+    <tag k="ele" v="22.252"/>
+  </node>
+  <node id="8905" lat="35.90321348285" lon="139.93364164783">
+    <tag k="local_x" v="3772.6078"/>
+    <tag k="local_y" v="73738.6533"/>
+    <tag k="ele" v="22.125"/>
+  </node>
+  <node id="8906" lat="35.90320978202" lon="139.93364368657">
+    <tag k="local_x" v="3772.7873"/>
+    <tag k="local_y" v="73738.2408"/>
+    <tag k="ele" v="22.125"/>
+  </node>
+  <node id="8907" lat="35.90322546753" lon="139.93345651994">
+    <tag k="local_x" v="3755.9159"/>
+    <tag k="local_y" v="73740.165"/>
+    <tag k="ele" v="24.955"/>
+  </node>
+  <node id="8908" lat="35.90321537239" lon="139.93346266919">
+    <tag k="local_x" v="3756.4586"/>
+    <tag k="local_y" v="73739.0392"/>
+    <tag k="ele" v="24.955"/>
+  </node>
+  <node id="8909" lat="35.90331679443" lon="139.93363221123">
+    <tag k="local_x" v="3771.8813"/>
+    <tag k="local_y" v="73750.1218"/>
+    <tag k="ele" v="24.794"/>
+  </node>
+  <node id="8910" lat="35.90330686048" lon="139.93363874615">
+    <tag k="local_x" v="3772.459"/>
+    <tag k="local_y" v="73749.0135"/>
+    <tag k="ele" v="24.794"/>
+  </node>
+  <node id="8911" lat="35.90324808286" lon="139.9334352729">
+    <tag k="local_x" v="3754.0259"/>
+    <tag k="local_y" v="73742.6944"/>
+    <tag k="ele" v="21.621"/>
+  </node>
+  <node id="8912" lat="35.90324685567" lon="139.93344002439">
+    <tag k="local_x" v="3754.4532"/>
+    <tag k="local_y" v="73742.5536"/>
+    <tag k="ele" v="21.621"/>
+  </node>
+  <node id="8913" lat="35.90328735789" lon="139.93345338233">
+    <tag k="local_x" v="3755.7077"/>
+    <tag k="local_y" v="73747.0329"/>
+    <tag k="ele" v="22.257"/>
+  </node>
+  <node id="8914" lat="35.90328888738" lon="139.93345800042">
+    <tag k="local_x" v="3756.1263"/>
+    <tag k="local_y" v="73747.198"/>
+    <tag k="ele" v="22.257"/>
+  </node>
+  <node id="8915" lat="35.90330884265" lon="139.93347182137">
+    <tag k="local_x" v="3757.3977"/>
+    <tag k="local_y" v="73749.3978"/>
+    <tag k="ele" v="22.146"/>
+  </node>
+  <node id="8916" lat="35.90331258786" lon="139.93346990724">
+    <tag k="local_x" v="3757.2295"/>
+    <tag k="local_y" v="73749.8151"/>
+    <tag k="ele" v="22.146"/>
+  </node>
+  <node id="8917" lat="35.90317591061" lon="139.93358838129">
+    <tag k="local_x" v="3767.7554"/>
+    <tag k="local_y" v="73734.5383"/>
+    <tag k="ele" v="24.809"/>
+  </node>
+  <node id="8918" lat="35.9031811682" lon="139.93360062977">
+    <tag k="local_x" v="3768.8671"/>
+    <tag k="local_y" v="73735.1094"/>
+    <tag k="ele" v="24.809"/>
+  </node>
+  <node id="8919" lat="35.90332412372" lon="139.93348791907">
+    <tag k="local_x" v="3758.8689"/>
+    <tag k="local_y" v="73751.0769"/>
+    <tag k="ele" v="24.851"/>
+  </node>
+  <node id="8920" lat="35.90332942793" lon="139.93350013702">
+    <tag k="local_x" v="3759.9779"/>
+    <tag k="local_y" v="73751.6532"/>
+    <tag k="ele" v="24.851"/>
+  </node>
+  <node id="8921" lat="35.90316452416" lon="139.93357236985">
+    <tag k="local_x" v="3766.2967"/>
+    <tag k="local_y" v="73733.2911"/>
+    <tag k="ele" v="21.687"/>
+  </node>
+  <node id="8922" lat="35.90316819962" lon="139.93357447917">
+    <tag k="local_x" v="3766.4915"/>
+    <tag k="local_y" v="73733.6967"/>
+    <tag k="ele" v="21.687"/>
+  </node>
+  <node id="8923" lat="35.90317815431" lon="139.93352317907">
+    <tag k="local_x" v="3761.8741"/>
+    <tag k="local_y" v="73734.8514"/>
+    <tag k="ele" v="22.267"/>
+  </node>
+  <node id="8924" lat="35.90318183851" lon="139.93352109512">
+    <tag k="local_x" v="3761.6905"/>
+    <tag k="local_y" v="73735.2621"/>
+    <tag k="ele" v="22.267"/>
+  </node>
+  <node id="8925" lat="35.90319227879" lon="139.9334955402">
+    <tag k="local_x" v="3759.397"/>
+    <tag k="local_y" v="73736.4453"/>
+    <tag k="ele" v="22.106"/>
+  </node>
+  <node id="8926" lat="35.90319072957" lon="139.93349093346">
+    <tag k="local_x" v="3758.9794"/>
+    <tag k="local_y" v="73736.278"/>
+    <tag k="ele" v="22.106"/>
+  </node>
+  <node id="8927" lat="35.90334844579" lon="139.93352514823">
+    <tag k="local_x" v="3762.258"/>
+    <tag k="local_y" v="73753.738"/>
+    <tag k="ele" v="24.827"/>
+  </node>
+  <node id="8928" lat="35.90334300984" lon="139.93351301848">
+    <tag k="local_x" v="3761.1568"/>
+    <tag k="local_y" v="73753.147"/>
+    <tag k="ele" v="24.827"/>
+  </node>
+  <node id="8929" lat="35.90319887765" lon="139.93362510777">
+    <tag k="local_x" v="3771.0975"/>
+    <tag k="local_y" v="73737.0496"/>
+    <tag k="ele" v="24.808"/>
+  </node>
+  <node id="8930" lat="35.90319322846" lon="139.93361312717">
+    <tag k="local_x" v="3770.0095"/>
+    <tag k="local_y" v="73736.4348"/>
+    <tag k="ele" v="24.808"/>
+  </node>
+  <node id="8931" lat="35.90335878368" lon="139.93354054435">
+    <tag k="local_x" v="3763.6599"/>
+    <tag k="local_y" v="73754.8695"/>
+    <tag k="ele" v="21.548"/>
+  </node>
+  <node id="8932" lat="35.90335533445" lon="139.93353792115">
+    <tag k="local_x" v="3763.419"/>
+    <tag k="local_y" v="73754.4895"/>
+    <tag k="ele" v="21.548"/>
+  </node>
+  <node id="8933" lat="35.90334551774" lon="139.93358790638">
+    <tag k="local_x" v="3767.9179"/>
+    <tag k="local_y" v="73753.3514"/>
+    <tag k="ele" v="22.181"/>
+  </node>
+  <node id="8934" lat="35.90334174842" lon="139.93358974547">
+    <tag k="local_x" v="3768.0793"/>
+    <tag k="local_y" v="73752.9315"/>
+    <tag k="ele" v="22.181"/>
+  </node>
+  <node id="8935" lat="35.90333041537" lon="139.93361395716">
+    <tag k="local_x" v="3770.2505"/>
+    <tag k="local_y" v="73751.6506"/>
+    <tag k="ele" v="22.115"/>
+  </node>
+  <node id="8936" lat="35.90333181916" lon="139.93361863457">
+    <tag k="local_x" v="3770.6743"/>
+    <tag k="local_y" v="73751.8017"/>
+    <tag k="ele" v="22.115"/>
+  </node>
+  <node id="8937" lat="35.90291841516" lon="139.93295926985">
+    <tag k="local_x" v="3710.6708"/>
+    <tag k="local_y" v="73706.5971"/>
+    <tag k="ele" v="24.872"/>
+  </node>
+  <node id="8938" lat="35.90291284294" lon="139.9329472329">
+    <tag k="local_x" v="3709.5778"/>
+    <tag k="local_y" v="73705.9909"/>
+    <tag k="ele" v="24.872"/>
+  </node>
+  <node id="8939" lat="35.90303513036" lon="139.93283450749">
+    <tag k="local_x" v="3699.5533"/>
+    <tag k="local_y" v="73719.666"/>
+    <tag k="ele" v="24.809"/>
+  </node>
+  <node id="8940" lat="35.90304094804" lon="139.93284636608">
+    <tag k="local_x" v="3700.6305"/>
+    <tag k="local_y" v="73720.2996"/>
+    <tag k="ele" v="24.809"/>
+  </node>
+  <node id="8941" lat="35.90294692975" lon="139.9328696955">
+    <tag k="local_x" v="3702.6219"/>
+    <tag k="local_y" v="73709.8482"/>
+    <tag k="ele" v="24.685"/>
+  </node>
+  <node id="8942" lat="35.90295685079" lon="139.93286313188">
+    <tag k="local_x" v="3702.0416"/>
+    <tag k="local_y" v="73710.9551"/>
+    <tag k="ele" v="24.685"/>
+  </node>
+  <node id="9535" lat="35.90309824288" lon="139.93311064102">
+    <tag k="local_x" v="3724.5488"/>
+    <tag k="local_y" v="73726.3942"/>
+    <tag k="ele" v="19.2833"/>
+  </node>
+  <node id="9541" lat="35.90315401465" lon="139.93323803474">
+    <tag k="local_x" v="3736.1127"/>
+    <tag k="local_y" v="73732.4548"/>
+    <tag k="ele" v="19.3088"/>
+  </node>
+  <node id="10253" lat="35.90355238473" lon="139.93332791513">
+    <tag k="local_x" v="3744.7062"/>
+    <tag k="local_y" v="73776.553"/>
+    <tag k="ele" v="19.135"/>
+  </node>
+  <node id="10255" lat="35.9035647267" lon="139.93335791279">
+    <tag k="local_x" v="3747.4282"/>
+    <tag k="local_y" v="73777.8924"/>
+    <tag k="ele" v="19.1275"/>
+  </node>
+  <node id="10258" lat="35.90324056971" lon="139.93341715504">
+    <tag k="local_x" v="3752.3818"/>
+    <tag k="local_y" v="73741.8789"/>
+    <tag k="ele" v="19.3711"/>
+  </node>
+  <node id="10259" lat="35.90320519562" lon="139.93344095242">
+    <tag k="local_x" v="3754.4865"/>
+    <tag k="local_y" v="73737.9318"/>
+    <tag k="ele" v="19.3885"/>
+  </node>
+  <node id="10261" lat="35.90317755789" lon="139.93364930602">
+    <tag k="local_x" v="3773.2554"/>
+    <tag k="local_y" v="73734.661"/>
+    <tag k="ele" v="19.4002"/>
+  </node>
+  <node id="10262" lat="35.90311094411" lon="139.93369161583">
+    <tag k="local_x" v="3776.9929"/>
+    <tag k="local_y" v="73727.2306"/>
+    <tag k="ele" v="19.406"/>
+  </node>
+  <node id="10263" lat="35.903097437" lon="139.93366329722">
+    <tag k="local_x" v="3774.421"/>
+    <tag k="local_y" v="73725.7603"/>
+    <tag k="ele" v="19.4235"/>
+  </node>
+  <node id="10264" lat="35.90316436901" lon="139.93362037809">
+    <tag k="local_x" v="3770.6289"/>
+    <tag k="local_y" v="73733.2266"/>
+    <tag k="ele" v="19.4177"/>
+  </node>
+  <node id="10267" lat="35.90323763937" lon="139.93342849169">
+    <tag k="local_x" v="3753.4013"/>
+    <tag k="local_y" v="73741.5427"/>
+    <tag k="ele" v="20.54"/>
+  </node>
+  <node id="10268" lat="35.90321379263" lon="139.9334441703">
+    <tag k="local_x" v="3754.7873"/>
+    <tag k="local_y" v="73738.8822"/>
+    <tag k="ele" v="20.5097"/>
+  </node>
+  <node id="10270" lat="35.90325646292" lon="139.93354307856">
+    <tag k="local_x" v="3763.7647"/>
+    <tag k="local_y" v="73743.5177"/>
+    <tag k="ele" v="20.4896"/>
+  </node>
+  <node id="10271" lat="35.90324904516" lon="139.93357346094">
+    <tag k="local_x" v="3766.4975"/>
+    <tag k="local_y" v="73742.665"/>
+    <tag k="ele" v="20.4795"/>
+  </node>
+  <node id="10272" lat="35.90322377746" lon="139.93356405622">
+    <tag k="local_x" v="3765.6182"/>
+    <tag k="local_y" v="73739.8716"/>
+    <tag k="ele" v="20.4492"/>
+  </node>
+  <node id="10273" lat="35.90323180016" lon="139.93353752977">
+    <tag k="local_x" v="3763.2341"/>
+    <tag k="local_y" v="73740.7876"/>
+    <tag k="ele" v="20.4593"/>
+  </node>
+  <node id="10277" lat="35.90306090842" lon="139.93294282721">
+    <tag k="local_x" v="3709.3596"/>
+    <tag k="local_y" v="73722.4185"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="10284" lat="35.90306351232" lon="139.9329487329">
+    <tag k="local_x" v="3709.8957"/>
+    <tag k="local_y" v="73722.7015"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="10286" lat="35.90307126148" lon="139.9329663134">
+    <tag k="local_x" v="3711.4916"/>
+    <tag k="local_y" v="73723.5437"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="10288" lat="35.90311827663" lon="139.93307443789">
+    <tag k="local_x" v="3721.306"/>
+    <tag k="local_y" v="73728.652"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="10290" lat="35.90312600496" lon="139.93309221261">
+    <tag k="local_x" v="3722.9194"/>
+    <tag k="local_y" v="73729.4917"/>
+    <tag k="ele" v="19.2833"/>
+  </node>
+  <node id="10292" lat="35.90314568732" lon="139.93313700694">
+    <tag k="local_x" v="3726.9856"/>
+    <tag k="local_y" v="73731.6307"/>
+    <tag k="ele" v="19.308"/>
+  </node>
+  <node id="10294" lat="35.90314869596" lon="139.93314392225">
+    <tag k="local_x" v="3727.6133"/>
+    <tag k="local_y" v="73731.9576"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="10295" lat="35.90317015717" lon="139.93319308977">
+    <tag k="local_x" v="3732.0763"/>
+    <tag k="local_y" v="73734.2896"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="10296" lat="35.90318184023" lon="139.93321975067">
+    <tag k="local_x" v="3734.4964"/>
+    <tag k="local_y" v="73735.5592"/>
+    <tag k="ele" v="19.3088"/>
+  </node>
+  <node id="10297" lat="35.90319165217" lon="139.93324230894">
+    <tag k="local_x" v="3736.544"/>
+    <tag k="local_y" v="73736.6253"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="10299" lat="35.90319463656" lon="139.93324913371">
+    <tag k="local_x" v="3737.1635"/>
+    <tag k="local_y" v="73736.9496"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="10300" lat="35.90322017181" lon="139.93330763132">
+    <tag k="local_x" v="3742.4734"/>
+    <tag k="local_y" v="73739.7243"/>
+    <tag k="ele" v="19.3"/>
+  </node>
+  <node id="10301" lat="35.9032527805" lon="139.93338305927">
+    <tag k="local_x" v="3749.3197"/>
+    <tag k="local_y" v="73743.2669"/>
+    <tag k="ele" v="19.2908"/>
+  </node>
+  <node id="10311" lat="35.90355313873" lon="139.93422224199">
+    <tag k="local_x" v="3825.4131"/>
+    <tag k="local_y" v="73775.7558"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10313" lat="35.90357687237" lon="139.93420630466">
+    <tag k="local_x" v="3824.0036"/>
+    <tag k="local_y" v="73778.404"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10321" lat="35.90352935172" lon="139.93423805925">
+    <tag k="local_x" v="3826.8117"/>
+    <tag k="local_y" v="73773.1018"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10324" lat="35.90356481078" lon="139.93424850108">
+    <tag k="local_x" v="3827.7969"/>
+    <tag k="local_y" v="73777.0246"/>
+    <tag k="ele" v="19.3691"/>
+  </node>
+  <node id="10326" lat="35.90357453444" lon="139.93427037816">
+    <tag k="local_x" v="3829.7829"/>
+    <tag k="local_y" v="73778.0816"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="10327" lat="35.90358205486" lon="139.93428729709">
+    <tag k="local_x" v="3831.3188"/>
+    <tag k="local_y" v="73778.8991"/>
+    <tag k="ele" v="19.2578"/>
+  </node>
+  <node id="10329" lat="35.90358854354" lon="139.93423256486">
+    <tag k="local_x" v="3826.3875"/>
+    <tag k="local_y" v="73779.6727"/>
+    <tag k="ele" v="19.3691"/>
+  </node>
+  <node id="10331" lat="35.90359825913" lon="139.93425444649">
+    <tag k="local_x" v="3828.3739"/>
+    <tag k="local_y" v="73780.7288"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="10332" lat="35.90360578223" lon="139.93427136317">
+    <tag k="local_x" v="3829.9096"/>
+    <tag k="local_y" v="73781.5466"/>
+    <tag k="ele" v="19.2578"/>
+  </node>
+  <node id="10362" lat="35.90335840538" lon="139.9335365236">
+    <tag k="local_x" v="3763.2966"/>
+    <tag k="local_y" v="73754.8315"/>
+    <tag k="ele" v="19.225"/>
+  </node>
+  <node id="10363" lat="35.90340387669" lon="139.93350660683">
+    <tag k="local_x" v="3760.6519"/>
+    <tag k="local_y" v="73759.9046"/>
+    <tag k="ele" v="19.209"/>
+  </node>
+  <node id="10364" lat="35.90345109979" lon="139.93347557945">
+    <tag k="local_x" v="3757.9091"/>
+    <tag k="local_y" v="73765.1731"/>
+    <tag k="ele" v="19.163"/>
+  </node>
+  <node id="10365" lat="35.90345630448" lon="139.9334721265">
+    <tag k="local_x" v="3757.6038"/>
+    <tag k="local_y" v="73765.7538"/>
+    <tag k="ele" v="19.16"/>
+  </node>
+  <node id="10366" lat="35.90350874904" lon="139.93343740543">
+    <tag k="local_x" v="3754.534"/>
+    <tag k="local_y" v="73771.6051"/>
+    <tag k="ele" v="19.127"/>
+  </node>
+  <node id="10367" lat="35.90355138736" lon="139.93340918322">
+    <tag k="local_x" v="3752.0388"/>
+    <tag k="local_y" v="73776.3623"/>
+    <tag k="ele" v="19.119"/>
+  </node>
+  <node id="10370" lat="35.9035593936" lon="139.93415569583">
+    <tag k="local_x" v="3819.4154"/>
+    <tag k="local_y" v="73776.5151"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="10371" lat="35.90355700065" lon="139.93415018727">
+    <tag k="local_x" v="3818.9154"/>
+    <tag k="local_y" v="73776.2551"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="10372" lat="35.90352963828" lon="139.93408751938">
+    <tag k="local_x" v="3813.227"/>
+    <tag k="local_y" v="73773.2818"/>
+    <tag k="ele" v="19.328"/>
+  </node>
+  <node id="10373" lat="35.90350227837" lon="139.93402482601">
+    <tag k="local_x" v="3807.5363"/>
+    <tag k="local_y" v="73770.3088"/>
+    <tag k="ele" v="19.337"/>
+  </node>
+  <node id="10374" lat="35.90347491751" lon="139.93396213159">
+    <tag k="local_x" v="3801.8455"/>
+    <tag k="local_y" v="73767.3357"/>
+    <tag k="ele" v="19.353"/>
+  </node>
+  <node id="10375" lat="35.9034719448" lon="139.93395529774">
+    <tag k="local_x" v="3801.2252"/>
+    <tag k="local_y" v="73767.0127"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="10376" lat="35.90344150104" lon="139.93388554827">
+    <tag k="local_x" v="3794.894"/>
+    <tag k="local_y" v="73763.7046"/>
+    <tag k="ele" v="19.369"/>
+  </node>
+  <node id="10377" lat="35.90341105609" lon="139.93381577005">
+    <tag k="local_x" v="3788.5602"/>
+    <tag k="local_y" v="73760.3964"/>
+    <tag k="ele" v="19.341"/>
+  </node>
+  <node id="10378" lat="35.90340808363" lon="139.93380896502">
+    <tag k="local_x" v="3787.9425"/>
+    <tag k="local_y" v="73760.0734"/>
+    <tag k="ele" v="19.343"/>
+  </node>
+  <node id="10379" lat="35.90338280596" lon="139.93375101994">
+    <tag k="local_x" v="3782.6828"/>
+    <tag k="local_y" v="73757.3267"/>
+    <tag k="ele" v="19.327"/>
+  </node>
+  <node id="10380" lat="35.90335752852" lon="139.9336931037">
+    <tag k="local_x" v="3777.4257"/>
+    <tag k="local_y" v="73754.58"/>
+    <tag k="ele" v="19.309"/>
+  </node>
+  <node id="10381" lat="35.90333316727" lon="139.93363724409">
+    <tag k="local_x" v="3772.3553"/>
+    <tag k="local_y" v="73751.9329"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="10384" lat="35.90335420253" lon="139.93353949326">
+    <tag k="local_x" v="3763.5595"/>
+    <tag k="local_y" v="73754.3624"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10385" lat="35.90335057818" lon="139.9335425294">
+    <tag k="local_x" v="3763.8291"/>
+    <tag k="local_y" v="73753.9574"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10386" lat="35.90334720309" lon="139.93354581706">
+    <tag k="local_x" v="3764.1217"/>
+    <tag k="local_y" v="73753.5798"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10387" lat="35.90334402709" lon="139.93354939127">
+    <tag k="local_x" v="3764.4404"/>
+    <tag k="local_y" v="73753.224"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10388" lat="35.90334106715" lon="139.93355323519">
+    <tag k="local_x" v="3764.7837"/>
+    <tag k="local_y" v="73752.8919"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10389" lat="35.90333833752" lon="139.93355732866">
+    <tag k="local_x" v="3765.1498"/>
+    <tag k="local_y" v="73752.5851"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10390" lat="35.90333585335" lon="139.93356165155">
+    <tag k="local_x" v="3765.5369"/>
+    <tag k="local_y" v="73752.3053"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10391" lat="35.90333362615" lon="139.93356618154">
+    <tag k="local_x" v="3765.943"/>
+    <tag k="local_y" v="73752.0538"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10392" lat="35.90333166746" lon="139.93357089519">
+    <tag k="local_x" v="3766.366"/>
+    <tag k="local_y" v="73751.8319"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10393" lat="35.90332998695" lon="139.93357576801">
+    <tag k="local_x" v="3766.8037"/>
+    <tag k="local_y" v="73751.6407"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10394" lat="35.90332859435" lon="139.93358077659">
+    <tag k="local_x" v="3767.254"/>
+    <tag k="local_y" v="73751.4813"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10395" lat="35.90332749572" lon="139.93358589425">
+    <tag k="local_x" v="3767.7145"/>
+    <tag k="local_y" v="73751.3544"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10396" lat="35.90332669805" lon="139.93359109542">
+    <tag k="local_x" v="3768.1829"/>
+    <tag k="local_y" v="73751.2608"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10397" lat="35.90332620291" lon="139.93359635347">
+    <tag k="local_x" v="3768.6568"/>
+    <tag k="local_y" v="73751.2007"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10398" lat="35.90332601546" lon="139.93360164064">
+    <tag k="local_x" v="3769.1337"/>
+    <tag k="local_y" v="73751.1747"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10399" lat="35.90332613457" lon="139.93360693145">
+    <tag k="local_x" v="3769.6113"/>
+    <tag k="local_y" v="73751.1827"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10400" lat="35.9033265618" lon="139.93361219819">
+    <tag k="local_x" v="3770.0871"/>
+    <tag k="local_y" v="73751.2249"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10401" lat="35.90332729241" lon="139.93361741431">
+    <tag k="local_x" v="3770.5587"/>
+    <tag k="local_y" v="73751.3008"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10402" lat="35.90332832526" lon="139.93362255324">
+    <tag k="local_x" v="3771.0237"/>
+    <tag k="local_y" v="73751.4103"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10403" lat="35.90332965288" lon="139.93362758737">
+    <tag k="local_x" v="3771.4796"/>
+    <tag k="local_y" v="73751.5526"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10404" lat="35.90333130113" lon="139.93363258396">
+    <tag k="local_x" v="3771.9325"/>
+    <tag k="local_y" v="73751.7305"/>
+    <tag k="ele" v="19.2252"/>
+  </node>
+  <node id="10473" lat="35.90324620543" lon="139.93343756421">
+    <tag k="local_x" v="3754.2304"/>
+    <tag k="local_y" v="73742.4839"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="10485" lat="35.90332881651" lon="139.93346844949">
+    <tag k="local_x" v="3757.1176"/>
+    <tag k="local_y" v="73751.6166"/>
+    <tag k="ele" v="19.216"/>
+  </node>
+  <node id="10486" lat="35.90337406612" lon="139.93343864426">
+    <tag k="local_x" v="3754.4827"/>
+    <tag k="local_y" v="73756.665"/>
+    <tag k="ele" v="19.199"/>
+  </node>
+  <node id="10487" lat="35.90342139974" lon="139.93340747686">
+    <tag k="local_x" v="3751.7274"/>
+    <tag k="local_y" v="73761.9459"/>
+    <tag k="ele" v="19.162"/>
+  </node>
+  <node id="10488" lat="35.90342659842" lon="139.93340405833">
+    <tag k="local_x" v="3751.4252"/>
+    <tag k="local_y" v="73762.5259"/>
+    <tag k="ele" v="19.159"/>
+  </node>
+  <node id="10489" lat="35.90347951423" lon="139.93336930874">
+    <tag k="local_x" v="3748.3534"/>
+    <tag k="local_y" v="73768.4295"/>
+    <tag k="ele" v="19.126"/>
+  </node>
+  <node id="10490" lat="35.90352273592" lon="139.93334089251">
+    <tag k="local_x" v="3745.8414"/>
+    <tag k="local_y" v="73773.2516"/>
+    <tag k="ele" v="19.092"/>
+  </node>
+  <node id="10566" lat="35.90324872539" lon="139.93344285383">
+    <tag k="local_x" v="3754.7108"/>
+    <tag k="local_y" v="73742.7582"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10567" lat="35.90325123791" lon="139.9334473047">
+    <tag k="local_x" v="3755.1155"/>
+    <tag k="local_y" v="73743.0325"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10568" lat="35.90325395143" lon="139.93345144703">
+    <tag k="local_x" v="3755.4926"/>
+    <tag k="local_y" v="73743.3294"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10569" lat="35.90325689717" lon="139.93345534245">
+    <tag k="local_x" v="3755.8477"/>
+    <tag k="local_y" v="73743.6523"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10570" lat="35.90326006051" lon="139.93345897012">
+    <tag k="local_x" v="3756.1789"/>
+    <tag k="local_y" v="73743.9996"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10571" lat="35.90326342597" lon="139.9334623136">
+    <tag k="local_x" v="3756.4847"/>
+    <tag k="local_y" v="73744.3696"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10572" lat="35.90326697539" lon="139.93346535543">
+    <tag k="local_x" v="3756.7635"/>
+    <tag k="local_y" v="73744.7603"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10573" lat="35.90327069148" lon="139.93346808031">
+    <tag k="local_x" v="3757.0139"/>
+    <tag k="local_y" v="73745.1698"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10574" lat="35.90327455518" lon="139.93347047299">
+    <tag k="local_x" v="3757.2345"/>
+    <tag k="local_y" v="73745.596"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10575" lat="35.90327854837" lon="139.93347252374">
+    <tag k="local_x" v="3757.4244"/>
+    <tag k="local_y" v="73746.0369"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10576" lat="35.90328264841" lon="139.93347422067">
+    <tag k="local_x" v="3757.5825"/>
+    <tag k="local_y" v="73746.49"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10577" lat="35.9032868372" lon="139.93347555627">
+    <tag k="local_x" v="3757.7081"/>
+    <tag k="local_y" v="73746.9533"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10578" lat="35.90329109212" lon="139.93347652197">
+    <tag k="local_x" v="3757.8004"/>
+    <tag k="local_y" v="73747.4243"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10579" lat="35.90329539242" lon="139.93347711474">
+    <tag k="local_x" v="3757.8591"/>
+    <tag k="local_y" v="73747.9007"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10580" lat="35.90329971552" lon="139.93347733155">
+    <tag k="local_x" v="3757.8839"/>
+    <tag k="local_y" v="73748.38"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10581" lat="35.90330404067" lon="139.93347717045">
+    <tag k="local_x" v="3757.8746"/>
+    <tag k="local_y" v="73748.8599"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10582" lat="35.90330834534" lon="139.93347663177">
+    <tag k="local_x" v="3757.8312"/>
+    <tag k="local_y" v="73749.3379"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10583" lat="35.90331260794" lon="139.9334757202">
+    <tag k="local_x" v="3757.7541"/>
+    <tag k="local_y" v="73749.8116"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10584" lat="35.90331680773" lon="139.93347443826">
+    <tag k="local_x" v="3757.6435"/>
+    <tag k="local_y" v="73750.2787"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10585" lat="35.90332092226" lon="139.93347279289">
+    <tag k="local_x" v="3757.5"/>
+    <tag k="local_y" v="73750.7367"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10586" lat="35.90332500627" lon="139.93347075565">
+    <tag k="local_x" v="3757.3211"/>
+    <tag k="local_y" v="73751.1917"/>
+    <tag k="ele" v="19.2777"/>
+  </node>
+  <node id="10636" lat="35.90350411447" lon="139.93419236377">
+    <tag k="local_x" v="3822.6575"/>
+    <tag k="local_y" v="73770.3475"/>
+    <tag k="ele" v="19.383"/>
+  </node>
+  <node id="10637" lat="35.90348471881" lon="139.93414793192">
+    <tag k="local_x" v="3818.6244"/>
+    <tag k="local_y" v="73768.2399"/>
+    <tag k="ele" v="19.351"/>
+  </node>
+  <node id="10638" lat="35.90346535816" lon="139.93410348633">
+    <tag k="local_x" v="3814.5901"/>
+    <tag k="local_y" v="73766.1362"/>
+    <tag k="ele" v="19.375"/>
+  </node>
+  <node id="10639" lat="35.90344427464" lon="139.93405518319">
+    <tag k="local_x" v="3810.2056"/>
+    <tag k="local_y" v="73763.8452"/>
+    <tag k="ele" v="19.408"/>
+  </node>
+  <node id="10640" lat="35.90342288115" lon="139.93400608861">
+    <tag k="local_x" v="3805.7493"/>
+    <tag k="local_y" v="73761.5206"/>
+    <tag k="ele" v="19.414"/>
+  </node>
+  <node id="10641" lat="35.90340169011" lon="139.93395745897">
+    <tag k="local_x" v="3801.3352"/>
+    <tag k="local_y" v="73759.218"/>
+    <tag k="ele" v="19.435"/>
+  </node>
+  <node id="10642" lat="35.90338027231" lon="139.93390837252">
+    <tag k="local_x" v="3796.8796"/>
+    <tag k="local_y" v="73756.8907"/>
+    <tag k="ele" v="19.441"/>
+  </node>
+  <node id="10643" lat="35.90335905066" lon="139.93385965137">
+    <tag k="local_x" v="3792.4572"/>
+    <tag k="local_y" v="73754.5848"/>
+    <tag k="ele" v="19.421"/>
+  </node>
+  <node id="10644" lat="35.90333760805" lon="139.93381051655">
+    <tag k="local_x" v="3787.9972"/>
+    <tag k="local_y" v="73752.2548"/>
+    <tag k="ele" v="19.398"/>
+  </node>
+  <node id="10645" lat="35.90331657621" lon="139.93376225942">
+    <tag k="local_x" v="3783.6169"/>
+    <tag k="local_y" v="73749.9695"/>
+    <tag k="ele" v="19.378"/>
+  </node>
+  <node id="10646" lat="35.90329729946" lon="139.93371803784">
+    <tag k="local_x" v="3779.6029"/>
+    <tag k="local_y" v="73747.8749"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="10647" lat="35.90327802179" lon="139.93367381629">
+    <tag k="local_x" v="3775.5889"/>
+    <tag k="local_y" v="73745.7802"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10671" lat="35.90319145325" lon="139.93347405367">
+    <tag k="local_x" v="3757.457"/>
+    <tag k="local_y" v="73736.3749"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="10672" lat="35.90317371436" lon="139.93343377978">
+    <tag k="local_x" v="3753.8011"/>
+    <tag k="local_y" v="73734.447"/>
+    <tag k="ele" v="19.304"/>
+  </node>
+  <node id="10693" lat="35.90319537423" lon="139.93364338564">
+    <tag k="local_x" v="3772.7427"/>
+    <tag k="local_y" v="73736.643"/>
+    <tag k="ele" v="19.305"/>
+  </node>
+  <node id="10694" lat="35.90315032006" lon="139.93367297197">
+    <tag k="local_x" v="3775.3581"/>
+    <tag k="local_y" v="73731.6165"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10695" lat="35.90310273555" lon="139.93370422004">
+    <tag k="local_x" v="3778.1204"/>
+    <tag k="local_y" v="73726.3077"/>
+    <tag k="ele" v="19.363"/>
+  </node>
+  <node id="10696" lat="35.90309798856" lon="139.93370733661">
+    <tag k="local_x" v="3778.3959"/>
+    <tag k="local_y" v="73725.7781"/>
+    <tag k="ele" v="19.364"/>
+  </node>
+  <node id="10697" lat="35.90304539712" lon="139.93374187312">
+    <tag k="local_x" v="3781.4489"/>
+    <tag k="local_y" v="73719.9107"/>
+    <tag k="ele" v="19.39"/>
+  </node>
+  <node id="10698" lat="35.90299279222" lon="139.93377641752">
+    <tag k="local_x" v="3784.5026"/>
+    <tag k="local_y" v="73714.0418"/>
+    <tag k="ele" v="19.42"/>
+  </node>
+  <node id="10699" lat="35.90298495695" lon="139.93378161666">
+    <tag k="local_x" v="3784.9623"/>
+    <tag k="local_y" v="73713.1676"/>
+    <tag k="ele" v="19.421"/>
+  </node>
+  <node id="10702" lat="35.90295537785" lon="139.93371381524">
+    <tag k="local_x" v="3778.8079"/>
+    <tag k="local_y" v="73709.9535"/>
+    <tag k="ele" v="19.433"/>
+  </node>
+  <node id="10703" lat="35.90296371509" lon="139.93370828911">
+    <tag k="local_x" v="3778.3193"/>
+    <tag k="local_y" v="73710.8837"/>
+    <tag k="ele" v="19.428"/>
+  </node>
+  <node id="10704" lat="35.90301629597" lon="139.93367378268">
+    <tag k="local_x" v="3775.269"/>
+    <tag k="local_y" v="73716.7499"/>
+    <tag k="ele" v="19.389"/>
+  </node>
+  <node id="10705" lat="35.90306886429" lon="139.93363928412">
+    <tag k="local_x" v="3772.2194"/>
+    <tag k="local_y" v="73722.6147"/>
+    <tag k="ele" v="19.36"/>
+  </node>
+  <node id="10706" lat="35.90307407289" lon="139.93363586549">
+    <tag k="local_x" v="3771.9172"/>
+    <tag k="local_y" v="73723.1958"/>
+    <tag k="ele" v="19.361"/>
+  </node>
+  <node id="10707" lat="35.90312124526" lon="139.93360490881">
+    <tag k="local_x" v="3769.1807"/>
+    <tag k="local_y" v="73728.4586"/>
+    <tag k="ele" v="19.339"/>
+  </node>
+  <node id="10708" lat="35.90316618305" lon="139.93357541821">
+    <tag k="local_x" v="3766.5738"/>
+    <tag k="local_y" v="73733.4721"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="10711" lat="35.90327588095" lon="139.93366928951">
+    <tag k="local_x" v="3775.1778"/>
+    <tag k="local_y" v="73745.5472"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10712" lat="35.90327338974" lon="139.93366479956">
+    <tag k="local_x" v="3774.7696"/>
+    <tag k="local_y" v="73745.2753"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10713" lat="35.903270693" lon="139.93366061821">
+    <tag k="local_x" v="3774.389"/>
+    <tag k="local_y" v="73744.9803"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10714" lat="35.90326776045" lon="139.93365668382">
+    <tag k="local_x" v="3774.0304"/>
+    <tag k="local_y" v="73744.6589"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10715" lat="35.90326460848" lon="139.9336530161">
+    <tag k="local_x" v="3773.6956"/>
+    <tag k="local_y" v="73744.3129"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10716" lat="35.9032612508" lon="139.93364963483">
+    <tag k="local_x" v="3773.3864"/>
+    <tag k="local_y" v="73743.9438"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10717" lat="35.90325770556" lon="139.93364655526">
+    <tag k="local_x" v="3773.1042"/>
+    <tag k="local_y" v="73743.5536"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10718" lat="35.90325399097" lon="139.93364379489">
+    <tag k="local_x" v="3772.8506"/>
+    <tag k="local_y" v="73743.1443"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10719" lat="35.90325012515" lon="139.93364136677">
+    <tag k="local_x" v="3772.6268"/>
+    <tag k="local_y" v="73742.7179"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10720" lat="35.90324612897" lon="139.93363928392">
+    <tag k="local_x" v="3772.434"/>
+    <tag k="local_y" v="73742.2767"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10721" lat="35.90324202235" lon="139.93363755604">
+    <tag k="local_x" v="3772.2731"/>
+    <tag k="local_y" v="73741.8229"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10722" lat="35.90323782519" lon="139.93363619173">
+    <tag k="local_x" v="3772.1449"/>
+    <tag k="local_y" v="73741.3587"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10723" lat="35.90323356012" lon="139.93363519956">
+    <tag k="local_x" v="3772.0502"/>
+    <tag k="local_y" v="73740.8866"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10724" lat="35.9032292488" lon="139.93363458366">
+    <tag k="local_x" v="3771.9894"/>
+    <tag k="local_y" v="73740.409"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10725" lat="35.903224912" lon="139.93363434709">
+    <tag k="local_x" v="3771.9628"/>
+    <tag k="local_y" v="73739.9282"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10726" lat="35.90322057317" lon="139.93363449062">
+    <tag k="local_x" v="3771.9705"/>
+    <tag k="local_y" v="73739.4468"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10727" lat="35.90321625303" lon="139.933635014">
+    <tag k="local_x" v="3772.0125"/>
+    <tag k="local_y" v="73738.9671"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10728" lat="35.90321197411" lon="139.93363591469">
+    <tag k="local_x" v="3772.0886"/>
+    <tag k="local_y" v="73738.4916"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10729" lat="35.90320775891" lon="139.93363718796">
+    <tag k="local_x" v="3772.1984"/>
+    <tag k="local_y" v="73738.0228"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10730" lat="35.9032036281" lon="139.933638828">
+    <tag k="local_x" v="3772.3414"/>
+    <tag k="local_y" v="73737.563"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10731" lat="35.90319952875" lon="139.93364086322">
+    <tag k="local_x" v="3772.5201"/>
+    <tag k="local_y" v="73737.1063"/>
+    <tag k="ele" v="19.338"/>
+  </node>
+  <node id="10756" lat="35.90317042628" lon="139.93357242696">
+    <tag k="local_x" v="3766.309"/>
+    <tag k="local_y" v="73733.9457"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10757" lat="35.90317407662" lon="139.93356937386">
+    <tag k="local_x" v="3766.0379"/>
+    <tag k="local_y" v="73734.3536"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10758" lat="35.90317747498" lon="139.93356606706">
+    <tag k="local_x" v="3765.7436"/>
+    <tag k="local_y" v="73734.7338"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10759" lat="35.90318067243" lon="139.9335624704">
+    <tag k="local_x" v="3765.4229"/>
+    <tag k="local_y" v="73735.092"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10760" lat="35.90318365198" lon="139.93355860075">
+    <tag k="local_x" v="3765.0773"/>
+    <tag k="local_y" v="73735.4263"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10761" lat="35.90318639849" lon="139.93355447935">
+    <tag k="local_x" v="3764.7087"/>
+    <tag k="local_y" v="73735.735"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10762" lat="35.90318889772" lon="139.93355012635">
+    <tag k="local_x" v="3764.3189"/>
+    <tag k="local_y" v="73736.0165"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10763" lat="35.90319113635" lon="139.93354556519">
+    <tag k="local_x" v="3763.91"/>
+    <tag k="local_y" v="73736.2693"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10764" lat="35.90319310467" lon="139.93354081817">
+    <tag k="local_x" v="3763.484"/>
+    <tag k="local_y" v="73736.4923"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10765" lat="35.90319479117" lon="139.93353590982">
+    <tag k="local_x" v="3763.0431"/>
+    <tag k="local_y" v="73736.6842"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10766" lat="35.90319618707" lon="139.93353086685">
+    <tag k="local_x" v="3762.5897"/>
+    <tag k="local_y" v="73736.844"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10767" lat="35.90319728537" lon="139.93352571263">
+    <tag k="local_x" v="3762.1259"/>
+    <tag k="local_y" v="73736.9709"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10768" lat="35.90319808092" lon="139.93352047604">
+    <tag k="local_x" v="3761.6543"/>
+    <tag k="local_y" v="73737.0643"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10769" lat="35.90319856943" lon="139.93351518263">
+    <tag k="local_x" v="3761.1772"/>
+    <tag k="local_y" v="73737.1237"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10770" lat="35.90319874844" lon="139.93350985901">
+    <tag k="local_x" v="3760.697"/>
+    <tag k="local_y" v="73737.1488"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10771" lat="35.9031986164" lon="139.93350453403">
+    <tag k="local_x" v="3760.2163"/>
+    <tag k="local_y" v="73737.1394"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10772" lat="35.90319817535" lon="139.93349923425">
+    <tag k="local_x" v="3759.7375"/>
+    <tag k="local_y" v="73737.0957"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10773" lat="35.90319742553" lon="139.93349398737">
+    <tag k="local_x" v="3759.2631"/>
+    <tag k="local_y" v="73737.0177"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10774" lat="35.90319637258" lon="139.9334888188">
+    <tag k="local_x" v="3758.7954"/>
+    <tag k="local_y" v="73736.906"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10775" lat="35.90319502126" lon="139.93348375728">
+    <tag k="local_x" v="3758.337"/>
+    <tag k="local_y" v="73736.7611"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10776" lat="35.90319334664" lon="139.93347873557">
+    <tag k="local_x" v="3757.8818"/>
+    <tag k="local_y" v="73736.5803"/>
+    <tag k="ele" v="19.3127"/>
+  </node>
+  <node id="10835" lat="35.90317431455" lon="139.93276578673">
+    <tag k="local_x" v="3693.5204"/>
+    <tag k="local_y" v="73735.1719"/>
+    <tag k="ele" v="19.1542"/>
+  </node>
+  <node id="10837" lat="35.90316133704" lon="139.9327366234">
+    <tag k="local_x" v="3690.8729"/>
+    <tag k="local_y" v="73733.7612"/>
+    <tag k="ele" v="19.1542"/>
+  </node>
+  <node id="10841" lat="35.90318729295" lon="139.93279495006">
+    <tag k="local_x" v="3696.1679"/>
+    <tag k="local_y" v="73736.5827"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="10844" lat="35.90280696969" lon="139.9330106003">
+    <tag k="local_x" v="3715.168"/>
+    <tag k="local_y" v="73694.1851"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="10846" lat="35.90281990681" lon="139.93303979179">
+    <tag k="local_x" v="3717.818"/>
+    <tag k="local_y" v="73695.5913"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="10850" lat="35.90279403166" lon="139.93298140883">
+    <tag k="local_x" v="3712.518"/>
+    <tag k="local_y" v="73692.7788"/>
+    <tag k="ele" v="19.359"/>
+  </node>
+  <node id="10860" lat="35.9030313969" lon="139.93281785933">
+    <tag k="local_x" v="3698.0464"/>
+    <tag k="local_y" v="73719.2683"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="10861" lat="35.90315917428" lon="139.9327317634">
+    <tag k="local_x" v="3690.4317"/>
+    <tag k="local_y" v="73733.5261"/>
+    <tag k="ele" v="19.1542"/>
+  </node>
+  <node id="10864" lat="35.90306216136" lon="139.93288527888">
+    <tag k="local_x" v="3704.1678"/>
+    <tag k="local_y" v="73722.6142"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10865" lat="35.90318945393" lon="139.9327998123">
+    <tag k="local_x" v="3696.6093"/>
+    <tag k="local_y" v="73736.8176"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="10868" lat="35.90289725925" lon="139.93290642282">
+    <tag k="local_x" v="3705.8761"/>
+    <tag k="local_y" v="73704.3026"/>
+    <tag k="ele" v="19.289"/>
+  </node>
+  <node id="10869" lat="35.90295837889" lon="139.93286606894">
+    <tag k="local_x" v="3702.3085"/>
+    <tag k="local_y" v="73711.1217"/>
+    <tag k="ele" v="19.257"/>
+  </node>
+  <node id="10870" lat="35.90298440656" lon="139.93284888491">
+    <tag k="local_x" v="3700.7893"/>
+    <tag k="local_y" v="73714.0256"/>
+    <tag k="ele" v="19.234"/>
+  </node>
+  <node id="10871" lat="35.90302440486" lon="139.93282247545">
+    <tag k="local_x" v="3698.4545"/>
+    <tag k="local_y" v="73718.4882"/>
+    <tag k="ele" v="19.223"/>
+  </node>
+  <node id="10872" lat="35.90302937843" lon="139.9328191918">
+    <tag k="local_x" v="3698.1642"/>
+    <tag k="local_y" v="73719.0431"/>
+    <tag k="ele" v="19.22"/>
+  </node>
+  <node id="10876" lat="35.90279188592" lon="139.93297653643">
+    <tag k="local_x" v="3712.0757"/>
+    <tag k="local_y" v="73692.5456"/>
+    <tag k="ele" v="19.359"/>
+  </node>
+  <node id="10879" lat="35.90292701066" lon="139.93297439001">
+    <tag k="local_x" v="3712.0457"/>
+    <tag k="local_y" v="73707.5356"/>
+    <tag k="ele" v="19.359"/>
+  </node>
+  <node id="10880" lat="35.9028220633" lon="139.93304465741">
+    <tag k="local_x" v="3718.2597"/>
+    <tag k="local_y" v="73695.8257"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="10900" lat="35.90299251371" lon="139.93301844832">
+    <tag k="local_x" v="3716.101"/>
+    <tag k="local_y" v="73714.7577"/>
+    <tag k="ele" v="19.2909"/>
+  </node>
+  <node id="10901" lat="35.9029823623" lon="139.93299523093">
+    <tag k="local_x" v="3713.9935"/>
+    <tag k="local_y" v="73713.6546"/>
+    <tag k="ele" v="19.278"/>
+  </node>
+  <node id="10904" lat="35.90298494649" lon="139.93300115128">
+    <tag k="local_x" v="3714.5309"/>
+    <tag k="local_y" v="73713.9354"/>
+    <tag k="ele" v="19.28"/>
+  </node>
+  <node id="10905" lat="35.90297993579" lon="139.93299021379">
+    <tag k="local_x" v="3713.5378"/>
+    <tag k="local_y" v="73713.3904"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10906" lat="35.90297729043" lon="139.93298593096">
+    <tag k="local_x" v="3713.1481"/>
+    <tag k="local_y" v="73713.1012"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10907" lat="35.90297437249" lon="139.93298212162">
+    <tag k="local_x" v="3712.8008"/>
+    <tag k="local_y" v="73712.7813"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10908" lat="35.90297114525" lon="139.93297871093">
+    <tag k="local_x" v="3712.4891"/>
+    <tag k="local_y" v="73712.4267"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10909" lat="35.90296764508" lon="139.93297573386">
+    <tag k="local_x" v="3712.2162"/>
+    <tag k="local_y" v="73712.0414"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10910" lat="35.90296390927" lon="139.93297322536">
+    <tag k="local_x" v="3711.9853"/>
+    <tag k="local_y" v="73711.6295"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10911" lat="35.90295998042" lon="139.93297121367">
+    <tag k="local_x" v="3711.799"/>
+    <tag k="local_y" v="73711.1957"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10912" lat="35.902955902" lon="139.93296971816">
+    <tag k="local_x" v="3711.6591"/>
+    <tag k="local_y" v="73710.7448"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10913" lat="35.90295171745" lon="139.93296875819">
+    <tag k="local_x" v="3711.5674"/>
+    <tag k="local_y" v="73710.2816"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10914" lat="35.90294747462" lon="139.93296834309">
+    <tag k="local_x" v="3711.5248"/>
+    <tag k="local_y" v="73709.8114"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10915" lat="35.90294321955" lon="139.93296847667">
+    <tag k="local_x" v="3711.5317"/>
+    <tag k="local_y" v="73709.3393"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10916" lat="35.902939" lon="139.93296915941">
+    <tag k="local_x" v="3711.5882"/>
+    <tag k="local_y" v="73708.8706"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10917" lat="35.90293486099" lon="139.93297038182">
+    <tag k="local_x" v="3711.6935"/>
+    <tag k="local_y" v="73708.4103"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10918" lat="35.90293073975" lon="139.93297218466">
+    <tag k="local_x" v="3711.8512"/>
+    <tag k="local_y" v="73707.9514"/>
+    <tag k="ele" v="19.2778"/>
+  </node>
+  <node id="10968" lat="35.90305925903" lon="139.93288870427">
+    <tag k="local_x" v="3704.4734"/>
+    <tag k="local_y" v="73722.2889"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10969" lat="35.90305670697" lon="139.93289360319">
+    <tag k="local_x" v="3704.9124"/>
+    <tag k="local_y" v="73722.001"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10970" lat="35.90305547213" lon="139.93289820185">
+    <tag k="local_x" v="3705.3259"/>
+    <tag k="local_y" v="73721.8595"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10971" lat="35.90305456979" lon="139.93290217107">
+    <tag k="local_x" v="3705.683"/>
+    <tag k="local_y" v="73721.7555"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10972" lat="35.90305414406" lon="139.93290630898">
+    <tag k="local_x" v="3706.0559"/>
+    <tag k="local_y" v="73721.7042"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10973" lat="35.90305394428" lon="139.93291071312">
+    <tag k="local_x" v="3706.4531"/>
+    <tag k="local_y" v="73721.6777"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10974" lat="35.90305404706" lon="139.93291598862">
+    <tag k="local_x" v="3706.9293"/>
+    <tag k="local_y" v="73721.6839"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10975" lat="35.90305434602" lon="139.93292102103">
+    <tag k="local_x" v="3707.3838"/>
+    <tag k="local_y" v="73721.7121"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10977" lat="35.90305491179" lon="139.9329264532">
+    <tag k="local_x" v="3707.8747"/>
+    <tag k="local_y" v="73721.7695"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10979" lat="35.90305650103" lon="139.93293190821">
+    <tag k="local_x" v="3708.3689"/>
+    <tag k="local_y" v="73721.9404"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="10980" lat="35.90305841991" lon="139.93293712276">
+    <tag k="local_x" v="3708.8418"/>
+    <tag k="local_y" v="73722.1481"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="11006" lat="35.90294154108" lon="139.93386829009">
+    <tag k="local_x" v="3792.7314"/>
+    <tag k="local_y" v="73708.2666"/>
+    <tag k="ele" v="19.5663"/>
+  </node>
+  <node id="11007" lat="35.90302636031" lon="139.93405448598">
+    <tag k="local_x" v="3809.6369"/>
+    <tag k="local_y" v="73717.4913"/>
+    <tag k="ele" v="19.6169"/>
+  </node>
+  <node id="11009" lat="35.90296512109" lon="139.93385201132">
+    <tag k="local_x" v="3791.2909"/>
+    <tag k="local_y" v="73710.8981"/>
+    <tag k="ele" v="19.5663"/>
+  </node>
+  <node id="11010" lat="35.90304995782" lon="139.93403824579">
+    <tag k="local_x" v="3808.1999"/>
+    <tag k="local_y" v="73720.1247"/>
+    <tag k="ele" v="19.6169"/>
+  </node>
+  <node id="11056" lat="35.90289423525" lon="139.93369689226">
+    <tag k="local_x" v="3777.2067"/>
+    <tag k="local_y" v="73703.1883"/>
+    <tag k="ele" v="19.6223"/>
+  </node>
+  <node id="11058" lat="35.90287065526" lon="139.93371317106">
+    <tag k="local_x" v="3778.6472"/>
+    <tag k="local_y" v="73700.5568"/>
+    <tag k="ele" v="19.6223"/>
+  </node>
+  <node id="11061" lat="35.90298034476" lon="139.93377849047">
+    <tag k="local_x" v="3784.6746"/>
+    <tag k="local_y" v="73712.6591"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11062" lat="35.90297714858" lon="139.933781215">
+    <tag k="local_x" v="3784.9166"/>
+    <tag k="local_y" v="73712.3019"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11063" lat="35.90297452766" lon="139.93378384537">
+    <tag k="local_x" v="3785.1508"/>
+    <tag k="local_y" v="73712.0086"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11064" lat="35.90297207562" lon="139.93378671173">
+    <tag k="local_x" v="3785.4065"/>
+    <tag k="local_y" v="73711.7338"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11065" lat="35.90296980764" lon="139.93378979614">
+    <tag k="local_x" v="3785.6821"/>
+    <tag k="local_y" v="73711.4792"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11066" lat="35.90296773619" lon="139.93379308291">
+    <tag k="local_x" v="3785.9762"/>
+    <tag k="local_y" v="73711.2462"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11067" lat="35.90296587281" lon="139.93379655084">
+    <tag k="local_x" v="3786.2869"/>
+    <tag k="local_y" v="73711.0361"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11068" lat="35.90296422815" lon="139.93380018205">
+    <tag k="local_x" v="3786.6126"/>
+    <tag k="local_y" v="73710.8501"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11069" lat="35.90296281193" lon="139.93380395426">
+    <tag k="local_x" v="3786.9513"/>
+    <tag k="local_y" v="73710.6893"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11070" lat="35.90296163209" lon="139.93380784629">
+    <tag k="local_x" v="3787.3011"/>
+    <tag k="local_y" v="73710.5546"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11071" lat="35.90296069474" lon="139.93381183702">
+    <tag k="local_x" v="3787.6601"/>
+    <tag k="local_y" v="73710.4467"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11072" lat="35.90296000508" lon="139.933815902">
+    <tag k="local_x" v="3788.0261"/>
+    <tag k="local_y" v="73710.3662"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11073" lat="35.90295956741" lon="139.93382001789">
+    <tag k="local_x" v="3788.397"/>
+    <tag k="local_y" v="73710.3136"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11074" lat="35.90295938424" lon="139.93382416361">
+    <tag k="local_x" v="3788.7709"/>
+    <tag k="local_y" v="73710.2892"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11075" lat="35.90295945624" lon="139.93382831256">
+    <tag k="local_x" v="3789.1454"/>
+    <tag k="local_y" v="73710.2931"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11076" lat="35.90295978321" lon="139.93383244257">
+    <tag k="local_x" v="3789.5185"/>
+    <tag k="local_y" v="73710.3253"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11077" lat="35.90296036313" lon="139.9338365293">
+    <tag k="local_x" v="3789.888"/>
+    <tag k="local_y" v="73710.3856"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11078" lat="35.9029611922" lon="139.93384054953">
+    <tag k="local_x" v="3790.2518"/>
+    <tag k="local_y" v="73710.4736"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11079" lat="35.90296226571" lon="139.93384448115">
+    <tag k="local_x" v="3790.6079"/>
+    <tag k="local_y" v="73710.5888"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11080" lat="35.9029637842" lon="139.93384887664">
+    <tag k="local_x" v="3791.0064"/>
+    <tag k="local_y" v="73710.7529"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11081" lat="35.90296510311" lon="139.9337514972">
+    <tag k="local_x" v="3782.2202"/>
+    <tag k="local_y" v="73710.9951"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11082" lat="35.9029610775" lon="139.93375493208">
+    <tag k="local_x" v="3782.5253"/>
+    <tag k="local_y" v="73710.5452"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11083" lat="35.9029568755" lon="139.93375911509">
+    <tag k="local_x" v="3782.8977"/>
+    <tag k="local_y" v="73710.075"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11084" lat="35.90295294284" lon="139.93376367679">
+    <tag k="local_x" v="3783.3046"/>
+    <tag k="local_y" v="73709.6343"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11085" lat="35.9029493009" lon="139.9337685914">
+    <tag k="local_x" v="3783.7437"/>
+    <tag k="local_y" v="73709.2255"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11086" lat="35.90294597197" lon="139.93377382982">
+    <tag k="local_x" v="3784.2124"/>
+    <tag k="local_y" v="73708.8511"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11087" lat="35.90294297294" lon="139.93377936412">
+    <tag k="local_x" v="3784.7082"/>
+    <tag k="local_y" v="73708.513"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11088" lat="35.90294032334" lon="139.93378516078">
+    <tag k="local_x" v="3785.2281"/>
+    <tag k="local_y" v="73708.2134"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11089" lat="35.90293803731" lon="139.93379118749">
+    <tag k="local_x" v="3785.7692"/>
+    <tag k="local_y" v="73707.9539"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11090" lat="35.90293612716" lon="139.93379741083">
+    <tag k="local_x" v="3786.3285"/>
+    <tag k="local_y" v="73707.7359"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11091" lat="35.90293460521" lon="139.93380379408">
+    <tag k="local_x" v="3786.9027"/>
+    <tag k="local_y" v="73707.5608"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11092" lat="35.90293348015" lon="139.93381030165">
+    <tag k="local_x" v="3787.4886"/>
+    <tag k="local_y" v="73707.4296"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11093" lat="35.90293275794" lon="139.93381689468">
+    <tag k="local_x" v="3788.0827"/>
+    <tag k="local_y" v="73707.343"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11094" lat="35.90293244277" lon="139.93382353766">
+    <tag k="local_x" v="3788.6818"/>
+    <tag k="local_y" v="73707.3015"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11095" lat="35.90293253701" lon="139.93383019067">
+    <tag k="local_x" v="3789.2823"/>
+    <tag k="local_y" v="73707.3054"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11096" lat="35.90293304032" lon="139.93383681823">
+    <tag k="local_x" v="3789.881"/>
+    <tag k="local_y" v="73707.3547"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11097" lat="35.90293394875" lon="139.93384337942">
+    <tag k="local_x" v="3790.4742"/>
+    <tag k="local_y" v="73707.449"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11098" lat="35.90293525837" lon="139.93384983882">
+    <tag k="local_x" v="3791.0587"/>
+    <tag k="local_y" v="73707.5879"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11099" lat="35.90293696163" lon="139.93385615886">
+    <tag k="local_x" v="3791.6311"/>
+    <tag k="local_y" v="73707.7706"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11100" lat="35.90293884215" lon="139.93386172854">
+    <tag k="local_x" v="3792.136"/>
+    <tag k="local_y" v="73707.9737"/>
+    <tag k="ele" v="19.4555"/>
+  </node>
+  <node id="11106" lat="35.90303091201" lon="139.93370788962">
+    <tag k="local_x" v="3778.3646"/>
+    <tag k="local_y" v="73718.3375"/>
+    <tag k="ele" v="19.452"/>
+  </node>
+  <node id="11108" lat="35.9030075772" lon="139.93394521221">
+    <tag k="local_x" v="3799.753"/>
+    <tag k="local_y" v="73715.5155"/>
+    <tag k="ele" v="19.5916"/>
+  </node>
+  <node id="11109" lat="35.90298410841" lon="139.93396173326">
+    <tag k="local_x" v="3801.2155"/>
+    <tag k="local_y" v="73712.8961"/>
+    <tag k="ele" v="19.5916"/>
+  </node>
+  <node id="11111" lat="35.90289328153" lon="139.93386870138">
+    <tag k="local_x" v="3792.7101"/>
+    <tag k="local_y" v="73702.9133"/>
+    <tag k="ele" v="25"/>
+  </node>
+  <node id="11112" lat="35.90288262997" lon="139.93384488115">
+    <tag k="local_x" v="3790.5476"/>
+    <tag k="local_y" v="73701.7553"/>
+    <tag k="ele" v="25"/>
+  </node>
+  <node id="11123" lat="35.90297330539" lon="139.93386997721">
+    <tag k="local_x" v="3792.9221"/>
+    <tag k="local_y" v="73711.7882"/>
+    <tag k="ele" v="19.579"/>
+  </node>
+  <node id="11124" lat="35.90294970791" lon="139.93388621743">
+    <tag k="local_x" v="3794.3591"/>
+    <tag k="local_y" v="73709.1548"/>
+    <tag k="ele" v="19.579"/>
+  </node>
+  <node id="11132" lat="35.90297033088" lon="139.93386344817">
+    <tag k="local_x" v="3792.3293"/>
+    <tag k="local_y" v="73711.4647"/>
+    <tag k="ele" v="19.5727"/>
+  </node>
+  <node id="11133" lat="35.90294692119" lon="139.93388002385">
+    <tag k="local_x" v="3793.7968"/>
+    <tag k="local_y" v="73708.8518"/>
+    <tag k="ele" v="19.5727"/>
+  </node>
+  <way id="35">
+    <nd ref="2007"/>
+    <nd ref="2008"/>
+    <nd ref="2009"/>
+    <nd ref="1621"/>
+    <nd ref="1622"/>
+    <nd ref="1623"/>
+    <nd ref="1624"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="37">
+    <nd ref="1620"/>
+    <nd ref="1619"/>
+    <nd ref="1618"/>
+    <nd ref="1617"/>
+    <nd ref="1893"/>
+    <nd ref="1892"/>
+    <nd ref="1891"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="38">
+    <nd ref="2182"/>
+    <nd ref="2181"/>
+    <nd ref="11106"/>
+    <nd ref="2180"/>
+    <nd ref="2179"/>
+    <nd ref="2178"/>
+    <nd ref="2177"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="39">
+    <nd ref="1970"/>
+    <nd ref="1971"/>
+    <nd ref="1972"/>
+    <nd ref="1895"/>
+    <nd ref="1896"/>
+    <nd ref="1897"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="41">
+    <nd ref="1992"/>
+    <nd ref="1991"/>
+    <nd ref="1978"/>
+    <nd ref="1977"/>
+    <nd ref="1976"/>
+    <nd ref="1975"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="42">
+    <nd ref="2176"/>
+    <nd ref="2175"/>
+    <nd ref="2174"/>
+    <nd ref="2247"/>
+    <nd ref="2246"/>
+    <nd ref="2245"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="43">
+    <nd ref="2001"/>
+    <nd ref="2002"/>
+    <nd ref="2003"/>
+    <nd ref="2004"/>
+    <nd ref="1740"/>
+    <nd ref="1741"/>
+    <nd ref="1742"/>
+    <nd ref="1735"/>
+    <nd ref="1736"/>
+    <nd ref="1737"/>
+    <nd ref="1738"/>
+    <nd ref="1739"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="45">
+    <nd ref="1780"/>
+    <nd ref="1730"/>
+    <nd ref="1731"/>
+    <nd ref="1732"/>
+    <nd ref="1733"/>
+    <nd ref="1726"/>
+    <nd ref="1727"/>
+    <nd ref="1728"/>
+    <nd ref="1729"/>
+    <nd ref="1888"/>
+    <nd ref="1889"/>
+    <nd ref="1890"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="46">
+    <nd ref="2201"/>
+    <nd ref="2202"/>
+    <nd ref="1106"/>
+    <nd ref="1107"/>
+    <nd ref="1104"/>
+    <nd ref="1105"/>
+    <nd ref="1102"/>
+    <nd ref="1103"/>
+    <nd ref="1100"/>
+    <nd ref="1101"/>
+    <nd ref="2199"/>
+    <nd ref="2200"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="197">
+    <nd ref="1890"/>
+    <nd ref="5966"/>
+    <nd ref="5965"/>
+    <nd ref="1994"/>
+    <nd ref="1995"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="199">
+    <nd ref="1890"/>
+    <nd ref="5966"/>
+    <nd ref="5992"/>
+    <nd ref="5991"/>
+    <nd ref="5990"/>
+    <nd ref="5989"/>
+    <nd ref="5988"/>
+    <nd ref="5987"/>
+    <nd ref="5986"/>
+    <nd ref="5985"/>
+    <nd ref="5984"/>
+    <nd ref="5983"/>
+    <nd ref="5982"/>
+    <nd ref="5981"/>
+    <nd ref="5980"/>
+    <nd ref="5979"/>
+    <nd ref="1993"/>
+    <nd ref="1992"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="201">
+    <nd ref="1890"/>
+    <nd ref="5966"/>
+    <nd ref="6026"/>
+    <nd ref="6025"/>
+    <nd ref="6024"/>
+    <nd ref="6023"/>
+    <nd ref="6022"/>
+    <nd ref="6021"/>
+    <nd ref="6020"/>
+    <nd ref="6019"/>
+    <nd ref="6018"/>
+    <nd ref="6017"/>
+    <nd ref="6016"/>
+    <nd ref="2006"/>
+    <nd ref="2007"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="202">
+    <nd ref="2200"/>
+    <nd ref="5970"/>
+    <nd ref="6032"/>
+    <nd ref="6033"/>
+    <nd ref="6034"/>
+    <nd ref="6035"/>
+    <nd ref="6036"/>
+    <nd ref="6037"/>
+    <nd ref="6038"/>
+    <nd ref="6039"/>
+    <nd ref="6040"/>
+    <nd ref="6041"/>
+    <nd ref="6042"/>
+    <nd ref="6043"/>
+    <nd ref="2177"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="203">
+    <nd ref="1886"/>
+    <nd ref="6049"/>
+    <nd ref="6048"/>
+    <nd ref="2000"/>
+    <nd ref="2001"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="204">
+    <nd ref="2195"/>
+    <nd ref="5974"/>
+    <nd ref="1903"/>
+    <nd ref="1899"/>
+    <nd ref="1901"/>
+    <nd ref="5970"/>
+    <nd ref="2200"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="205">
+    <nd ref="1886"/>
+    <nd ref="6049"/>
+    <nd ref="6076"/>
+    <nd ref="6075"/>
+    <nd ref="6074"/>
+    <nd ref="6073"/>
+    <nd ref="6072"/>
+    <nd ref="6071"/>
+    <nd ref="6070"/>
+    <nd ref="6069"/>
+    <nd ref="6068"/>
+    <nd ref="6067"/>
+    <nd ref="6066"/>
+    <nd ref="6065"/>
+    <nd ref="6064"/>
+    <nd ref="6063"/>
+    <nd ref="5979"/>
+    <nd ref="1993"/>
+    <nd ref="1992"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="206">
+    <nd ref="2195"/>
+    <nd ref="5974"/>
+    <nd ref="6082"/>
+    <nd ref="6083"/>
+    <nd ref="6084"/>
+    <nd ref="6085"/>
+    <nd ref="6086"/>
+    <nd ref="6087"/>
+    <nd ref="6088"/>
+    <nd ref="6089"/>
+    <nd ref="6090"/>
+    <nd ref="6091"/>
+    <nd ref="6092"/>
+    <nd ref="6093"/>
+    <nd ref="6094"/>
+    <nd ref="6095"/>
+    <nd ref="6011"/>
+    <nd ref="2176"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="207">
+    <nd ref="1886"/>
+    <nd ref="6049"/>
+    <nd ref="6115"/>
+    <nd ref="6114"/>
+    <nd ref="6113"/>
+    <nd ref="6112"/>
+    <nd ref="6111"/>
+    <nd ref="6110"/>
+    <nd ref="6109"/>
+    <nd ref="6108"/>
+    <nd ref="6107"/>
+    <nd ref="6106"/>
+    <nd ref="6105"/>
+    <nd ref="6104"/>
+    <nd ref="6103"/>
+    <nd ref="6102"/>
+    <nd ref="6016"/>
+    <nd ref="2006"/>
+    <nd ref="2007"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="209">
+    <nd ref="1891"/>
+    <nd ref="6141"/>
+    <nd ref="5979"/>
+    <nd ref="1993"/>
+    <nd ref="1992"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="210">
+    <nd ref="2177"/>
+    <nd ref="6043"/>
+    <nd ref="1900"/>
+    <nd ref="1898"/>
+    <nd ref="6011"/>
+    <nd ref="2176"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="211">
+    <nd ref="1891"/>
+    <nd ref="6141"/>
+    <nd ref="6164"/>
+    <nd ref="6163"/>
+    <nd ref="6162"/>
+    <nd ref="6161"/>
+    <nd ref="6160"/>
+    <nd ref="6159"/>
+    <nd ref="6158"/>
+    <nd ref="6157"/>
+    <nd ref="6156"/>
+    <nd ref="6155"/>
+    <nd ref="6154"/>
+    <nd ref="6048"/>
+    <nd ref="2000"/>
+    <nd ref="2001"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="213">
+    <nd ref="1891"/>
+    <nd ref="6141"/>
+    <nd ref="6199"/>
+    <nd ref="6198"/>
+    <nd ref="6197"/>
+    <nd ref="6196"/>
+    <nd ref="6195"/>
+    <nd ref="6194"/>
+    <nd ref="6193"/>
+    <nd ref="6192"/>
+    <nd ref="6191"/>
+    <nd ref="6190"/>
+    <nd ref="6189"/>
+    <nd ref="6188"/>
+    <nd ref="6187"/>
+    <nd ref="5965"/>
+    <nd ref="1994"/>
+    <nd ref="1995"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="214">
+    <nd ref="2177"/>
+    <nd ref="6043"/>
+    <nd ref="6134"/>
+    <nd ref="6133"/>
+    <nd ref="6132"/>
+    <nd ref="6131"/>
+    <nd ref="6130"/>
+    <nd ref="6129"/>
+    <nd ref="6128"/>
+    <nd ref="6127"/>
+    <nd ref="6126"/>
+    <nd ref="6125"/>
+    <nd ref="6124"/>
+    <nd ref="6123"/>
+    <nd ref="6122"/>
+    <nd ref="6121"/>
+    <nd ref="5974"/>
+    <nd ref="2195"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="215">
+    <nd ref="1897"/>
+    <nd ref="6225"/>
+    <nd ref="6016"/>
+    <nd ref="2006"/>
+    <nd ref="2007"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="217">
+    <nd ref="1897"/>
+    <nd ref="6225"/>
+    <nd ref="6248"/>
+    <nd ref="6247"/>
+    <nd ref="6246"/>
+    <nd ref="6245"/>
+    <nd ref="6244"/>
+    <nd ref="6243"/>
+    <nd ref="6242"/>
+    <nd ref="6241"/>
+    <nd ref="6240"/>
+    <nd ref="6239"/>
+    <nd ref="6238"/>
+    <nd ref="6048"/>
+    <nd ref="2000"/>
+    <nd ref="2001"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="218">
+    <nd ref="2176"/>
+    <nd ref="6011"/>
+    <nd ref="6010"/>
+    <nd ref="6009"/>
+    <nd ref="6008"/>
+    <nd ref="6007"/>
+    <nd ref="6006"/>
+    <nd ref="6005"/>
+    <nd ref="6004"/>
+    <nd ref="6003"/>
+    <nd ref="6002"/>
+    <nd ref="6001"/>
+    <nd ref="6000"/>
+    <nd ref="5999"/>
+    <nd ref="5998"/>
+    <nd ref="5970"/>
+    <nd ref="2200"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="219">
+    <nd ref="1897"/>
+    <nd ref="6225"/>
+    <nd ref="6286"/>
+    <nd ref="6285"/>
+    <nd ref="6284"/>
+    <nd ref="6283"/>
+    <nd ref="6282"/>
+    <nd ref="6281"/>
+    <nd ref="6280"/>
+    <nd ref="6279"/>
+    <nd ref="6278"/>
+    <nd ref="6277"/>
+    <nd ref="6276"/>
+    <nd ref="6275"/>
+    <nd ref="6274"/>
+    <nd ref="6273"/>
+    <nd ref="5965"/>
+    <nd ref="1994"/>
+    <nd ref="1995"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="245">
+    <nd ref="2053"/>
+    <nd ref="2054"/>
+    <nd ref="1794"/>
+    <nd ref="1795"/>
+    <nd ref="1787"/>
+    <nd ref="1788"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="247">
+    <nd ref="1569"/>
+    <nd ref="1568"/>
+    <nd ref="1567"/>
+    <nd ref="1571"/>
+    <nd ref="2049"/>
+    <nd ref="2048"/>
+    <tag k="type" v="virtual"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="248">
+    <nd ref="2165"/>
+    <nd ref="1934"/>
+    <nd ref="1933"/>
+    <nd ref="1932"/>
+    <nd ref="2173"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="249">
+    <nd ref="2053"/>
+    <nd ref="2054"/>
+    <nd ref="1794"/>
+    <nd ref="1795"/>
+    <nd ref="5000"/>
+    <nd ref="4999"/>
+    <nd ref="4998"/>
+    <nd ref="4997"/>
+    <nd ref="4996"/>
+    <nd ref="4995"/>
+    <nd ref="4994"/>
+    <nd ref="4993"/>
+    <nd ref="4992"/>
+    <nd ref="4991"/>
+    <nd ref="4990"/>
+    <nd ref="4989"/>
+    <nd ref="4988"/>
+    <nd ref="4987"/>
+    <nd ref="4986"/>
+    <nd ref="1796"/>
+    <nd ref="1797"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="250">
+    <nd ref="2173"/>
+    <nd ref="5007"/>
+    <nd ref="5008"/>
+    <nd ref="5009"/>
+    <nd ref="5010"/>
+    <nd ref="5011"/>
+    <nd ref="5012"/>
+    <nd ref="5013"/>
+    <nd ref="5014"/>
+    <nd ref="5015"/>
+    <nd ref="5016"/>
+    <nd ref="5017"/>
+    <nd ref="5018"/>
+    <nd ref="5019"/>
+    <nd ref="5020"/>
+    <nd ref="5021"/>
+    <nd ref="5022"/>
+    <nd ref="2194"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="251">
+    <nd ref="1712"/>
+    <nd ref="1786"/>
+    <nd ref="5041"/>
+    <nd ref="5040"/>
+    <nd ref="5039"/>
+    <nd ref="5038"/>
+    <nd ref="5037"/>
+    <nd ref="5036"/>
+    <nd ref="5035"/>
+    <nd ref="5034"/>
+    <nd ref="5033"/>
+    <nd ref="5032"/>
+    <nd ref="5031"/>
+    <nd ref="5030"/>
+    <nd ref="5029"/>
+    <nd ref="5028"/>
+    <nd ref="5027"/>
+    <nd ref="5026"/>
+    <nd ref="2048"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="253">
+    <nd ref="1569"/>
+    <nd ref="5082"/>
+    <nd ref="5081"/>
+    <nd ref="5080"/>
+    <nd ref="5079"/>
+    <nd ref="5078"/>
+    <nd ref="5077"/>
+    <nd ref="5076"/>
+    <nd ref="5075"/>
+    <nd ref="5074"/>
+    <nd ref="5073"/>
+    <nd ref="5072"/>
+    <nd ref="5071"/>
+    <nd ref="5070"/>
+    <nd ref="5069"/>
+    <nd ref="5068"/>
+    <nd ref="5067"/>
+    <nd ref="5066"/>
+    <nd ref="1796"/>
+    <nd ref="1797"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="255">
+    <nd ref="1712"/>
+    <nd ref="1786"/>
+    <nd ref="5121"/>
+    <nd ref="5120"/>
+    <nd ref="5119"/>
+    <nd ref="5118"/>
+    <nd ref="5117"/>
+    <nd ref="5116"/>
+    <nd ref="5115"/>
+    <nd ref="5114"/>
+    <nd ref="5113"/>
+    <nd ref="5112"/>
+    <nd ref="5111"/>
+    <nd ref="5110"/>
+    <nd ref="5109"/>
+    <nd ref="5108"/>
+    <nd ref="5107"/>
+    <nd ref="1787"/>
+    <nd ref="1788"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="256">
+    <nd ref="2194"/>
+    <nd ref="5102"/>
+    <nd ref="5101"/>
+    <nd ref="5100"/>
+    <nd ref="5099"/>
+    <nd ref="5098"/>
+    <nd ref="5097"/>
+    <nd ref="5096"/>
+    <nd ref="5095"/>
+    <nd ref="5094"/>
+    <nd ref="5093"/>
+    <nd ref="5092"/>
+    <nd ref="5091"/>
+    <nd ref="5090"/>
+    <nd ref="5089"/>
+    <nd ref="5088"/>
+    <nd ref="5087"/>
+    <nd ref="5086"/>
+    <nd ref="2165"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="325">
+    <nd ref="346"/>
+    <nd ref="422"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="326">
+    <nd ref="348"/>
+    <nd ref="420"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="327">
+    <nd ref="361"/>
+    <nd ref="345"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="328">
+    <nd ref="363"/>
+    <nd ref="343"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="329">
+    <nd ref="288"/>
+    <nd ref="360"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="330">
+    <nd ref="290"/>
+    <nd ref="397"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="331">
+    <nd ref="423"/>
+    <nd ref="287"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="332">
+    <nd ref="425"/>
+    <nd ref="285"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="367">
+    <nd ref="1890"/>
+    <nd ref="2200"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="368">
+    <nd ref="8813"/>
+    <nd ref="8795"/>
+    <nd ref="8831"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="369"/>
+  </way>
+  <way id="369">
+    <nd ref="8897"/>
+    <nd ref="8898"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="370">
+    <nd ref="8817"/>
+    <nd ref="8799"/>
+    <nd ref="8835"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="371"/>
+  </way>
+  <way id="371">
+    <nd ref="8899"/>
+    <nd ref="8900"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="372">
+    <nd ref="8839"/>
+    <nd ref="8803"/>
+    <nd ref="8821"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="373"/>
+  </way>
+  <way id="373">
+    <nd ref="8901"/>
+    <nd ref="8902"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="1.250000"/>
+  </way>
+  <way id="374">
+    <nd ref="8855"/>
+    <nd ref="8847"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="375"/>
+  </way>
+  <way id="375">
+    <nd ref="8903"/>
+    <nd ref="8904"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="376">
+    <nd ref="8856"/>
+    <nd ref="8848"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="377"/>
+  </way>
+  <way id="377">
+    <nd ref="8905"/>
+    <nd ref="8906"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="378">
+    <nd ref="1886"/>
+    <nd ref="2195"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="379">
+    <nd ref="8811"/>
+    <nd ref="8793"/>
+    <nd ref="8829"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="380"/>
+  </way>
+  <way id="380">
+    <nd ref="8907"/>
+    <nd ref="8908"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="381">
+    <nd ref="8818"/>
+    <nd ref="8800"/>
+    <nd ref="8836"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="382"/>
+  </way>
+  <way id="382">
+    <nd ref="8909"/>
+    <nd ref="8910"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="383">
+    <nd ref="8840"/>
+    <nd ref="8804"/>
+    <nd ref="8822"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="384"/>
+  </way>
+  <way id="384">
+    <nd ref="8911"/>
+    <nd ref="8912"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="1.250000"/>
+  </way>
+  <way id="385">
+    <nd ref="8851"/>
+    <nd ref="8843"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="386"/>
+  </way>
+  <way id="386">
+    <nd ref="8913"/>
+    <nd ref="8914"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="387">
+    <nd ref="8852"/>
+    <nd ref="8844"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="388"/>
+  </way>
+  <way id="388">
+    <nd ref="8915"/>
+    <nd ref="8916"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="389">
+    <nd ref="1891"/>
+    <nd ref="2177"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="390">
+    <nd ref="8815"/>
+    <nd ref="8797"/>
+    <nd ref="8833"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="391"/>
+  </way>
+  <way id="391">
+    <nd ref="8917"/>
+    <nd ref="8918"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="392">
+    <nd ref="8816"/>
+    <nd ref="8798"/>
+    <nd ref="8834"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="393"/>
+  </way>
+  <way id="393">
+    <nd ref="8919"/>
+    <nd ref="8920"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="394">
+    <nd ref="8837"/>
+    <nd ref="8801"/>
+    <nd ref="8819"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="395"/>
+  </way>
+  <way id="395">
+    <nd ref="8921"/>
+    <nd ref="8922"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="1.250000"/>
+  </way>
+  <way id="396">
+    <nd ref="8849"/>
+    <nd ref="8841"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="397"/>
+  </way>
+  <way id="397">
+    <nd ref="8923"/>
+    <nd ref="8924"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="398">
+    <nd ref="8850"/>
+    <nd ref="8842"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="399"/>
+  </way>
+  <way id="399">
+    <nd ref="8925"/>
+    <nd ref="8926"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="400">
+    <nd ref="1897"/>
+    <nd ref="2176"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="401">
+    <nd ref="8812"/>
+    <nd ref="8794"/>
+    <nd ref="8830"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="402"/>
+  </way>
+  <way id="402">
+    <nd ref="8927"/>
+    <nd ref="8928"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="403">
+    <nd ref="8814"/>
+    <nd ref="8796"/>
+    <nd ref="8832"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="404"/>
+  </way>
+  <way id="404">
+    <nd ref="8929"/>
+    <nd ref="8930"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="405">
+    <nd ref="8838"/>
+    <nd ref="8802"/>
+    <nd ref="8820"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="406"/>
+  </way>
+  <way id="406">
+    <nd ref="8931"/>
+    <nd ref="8932"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="1.250000"/>
+  </way>
+  <way id="407">
+    <nd ref="8853"/>
+    <nd ref="8845"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="408"/>
+  </way>
+  <way id="408">
+    <nd ref="8933"/>
+    <nd ref="8934"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="409">
+    <nd ref="8854"/>
+    <nd ref="8846"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="410"/>
+  </way>
+  <way id="410">
+    <nd ref="8935"/>
+    <nd ref="8936"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_green"/>
+    <tag k="height" v="0.850000"/>
+  </way>
+  <way id="411">
+    <nd ref="2053"/>
+    <nd ref="2173"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="412">
+    <nd ref="8808"/>
+    <nd ref="8790"/>
+    <nd ref="8826"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="413"/>
+  </way>
+  <way id="413">
+    <nd ref="8937"/>
+    <nd ref="8938"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="415">
+    <nd ref="8810"/>
+    <nd ref="8792"/>
+    <nd ref="8828"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="416"/>
+  </way>
+  <way id="416">
+    <nd ref="8939"/>
+    <nd ref="8940"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="417">
+    <nd ref="2464"/>
+    <nd ref="2194"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="418">
+    <nd ref="8809"/>
+    <nd ref="8791"/>
+    <nd ref="8827"/>
+    <tag k="type" v="light_bulbs"/>
+    <tag k="traffic_light_id" v="419"/>
+  </way>
+  <way id="419">
+    <nd ref="8941"/>
+    <nd ref="8942"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+    <tag k="height" v="0.450000"/>
+  </way>
+  <way id="440">
+    <nd ref="1935"/>
+    <nd ref="1933"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="441">
+    <nd ref="1795"/>
+    <nd ref="1796"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="442">
+    <nd ref="1786"/>
+    <nd ref="1787"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="471">
+    <nd ref="1898"/>
+    <nd ref="1899"/>
+    <nd ref="1900"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="540">
+    <nd ref="3008"/>
+    <nd ref="3009"/>
+    <nd ref="3010"/>
+    <nd ref="3011"/>
+    <nd ref="3008"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="541">
+    <nd ref="3012"/>
+    <nd ref="3013"/>
+    <nd ref="3014"/>
+    <nd ref="3015"/>
+    <nd ref="3012"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="542">
+    <nd ref="3016"/>
+    <nd ref="3017"/>
+    <nd ref="3018"/>
+    <nd ref="3019"/>
+    <nd ref="3016"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="543">
+    <nd ref="3020"/>
+    <nd ref="3021"/>
+    <nd ref="3022"/>
+    <nd ref="3023"/>
+    <nd ref="3020"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="544">
+    <nd ref="3024"/>
+    <nd ref="3025"/>
+    <nd ref="3026"/>
+    <nd ref="3027"/>
+    <nd ref="3024"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="545">
+    <nd ref="3028"/>
+    <nd ref="3029"/>
+    <nd ref="3030"/>
+    <nd ref="3031"/>
+    <nd ref="3028"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="546">
+    <nd ref="3032"/>
+    <nd ref="3033"/>
+    <nd ref="3034"/>
+    <nd ref="3035"/>
+    <nd ref="3032"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="547">
+    <nd ref="3036"/>
+    <nd ref="3037"/>
+    <nd ref="3038"/>
+    <nd ref="3039"/>
+    <nd ref="3036"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="548">
+    <nd ref="3040"/>
+    <nd ref="3041"/>
+    <nd ref="3042"/>
+    <nd ref="3043"/>
+    <nd ref="3040"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="549">
+    <nd ref="3044"/>
+    <nd ref="3045"/>
+    <nd ref="3046"/>
+    <nd ref="3047"/>
+    <nd ref="3044"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="550">
+    <nd ref="3048"/>
+    <nd ref="3049"/>
+    <nd ref="3050"/>
+    <nd ref="3051"/>
+    <nd ref="3048"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="551">
+    <nd ref="3052"/>
+    <nd ref="3053"/>
+    <nd ref="3054"/>
+    <nd ref="3055"/>
+    <nd ref="3052"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="552">
+    <nd ref="3056"/>
+    <nd ref="3057"/>
+    <nd ref="3058"/>
+    <nd ref="3059"/>
+    <nd ref="3056"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="553">
+    <nd ref="3060"/>
+    <nd ref="3061"/>
+    <nd ref="3062"/>
+    <nd ref="3063"/>
+    <nd ref="3060"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="554">
+    <nd ref="3064"/>
+    <nd ref="3065"/>
+    <nd ref="3066"/>
+    <nd ref="3067"/>
+    <nd ref="3064"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="555">
+    <nd ref="3068"/>
+    <nd ref="3069"/>
+    <nd ref="3070"/>
+    <nd ref="3071"/>
+    <nd ref="3068"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="556">
+    <nd ref="3072"/>
+    <nd ref="3073"/>
+    <nd ref="3074"/>
+    <nd ref="3075"/>
+    <nd ref="3072"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="557">
+    <nd ref="3076"/>
+    <nd ref="3077"/>
+    <nd ref="3078"/>
+    <nd ref="3079"/>
+    <nd ref="3076"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="558">
+    <nd ref="3080"/>
+    <nd ref="3081"/>
+    <nd ref="3082"/>
+    <nd ref="3083"/>
+    <nd ref="3080"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="559">
+    <nd ref="3084"/>
+    <nd ref="3085"/>
+    <nd ref="3086"/>
+    <nd ref="3087"/>
+    <nd ref="3084"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="560">
+    <nd ref="3088"/>
+    <nd ref="3089"/>
+    <nd ref="3090"/>
+    <nd ref="3091"/>
+    <nd ref="3088"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="561">
+    <nd ref="3092"/>
+    <nd ref="3093"/>
+    <nd ref="3094"/>
+    <nd ref="3095"/>
+    <nd ref="3092"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="562">
+    <nd ref="3096"/>
+    <nd ref="3097"/>
+    <nd ref="3098"/>
+    <nd ref="3099"/>
+    <nd ref="3096"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="563">
+    <nd ref="3100"/>
+    <nd ref="3101"/>
+    <nd ref="3102"/>
+    <nd ref="3103"/>
+    <nd ref="3100"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="564">
+    <nd ref="3104"/>
+    <nd ref="3105"/>
+    <nd ref="3106"/>
+    <nd ref="3107"/>
+    <nd ref="3104"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="565">
+    <nd ref="3108"/>
+    <nd ref="3109"/>
+    <nd ref="3110"/>
+    <nd ref="3111"/>
+    <nd ref="3108"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="566">
+    <nd ref="3112"/>
+    <nd ref="3113"/>
+    <nd ref="3114"/>
+    <nd ref="3115"/>
+    <nd ref="3112"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="567">
+    <nd ref="3116"/>
+    <nd ref="3117"/>
+    <nd ref="3118"/>
+    <nd ref="3119"/>
+    <nd ref="3116"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="568">
+    <nd ref="3120"/>
+    <nd ref="3121"/>
+    <nd ref="3122"/>
+    <nd ref="3123"/>
+    <nd ref="3120"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="569">
+    <nd ref="3124"/>
+    <nd ref="3125"/>
+    <nd ref="3126"/>
+    <nd ref="3127"/>
+    <nd ref="3124"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="570">
+    <nd ref="3128"/>
+    <nd ref="3129"/>
+    <nd ref="3130"/>
+    <nd ref="3131"/>
+    <nd ref="3128"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="571">
+    <nd ref="3132"/>
+    <nd ref="3133"/>
+    <nd ref="3134"/>
+    <nd ref="3135"/>
+    <nd ref="3132"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="572">
+    <nd ref="3136"/>
+    <nd ref="3137"/>
+    <nd ref="3138"/>
+    <nd ref="3139"/>
+    <nd ref="3136"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="573">
+    <nd ref="3140"/>
+    <nd ref="3141"/>
+    <nd ref="3142"/>
+    <nd ref="3143"/>
+    <nd ref="3140"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="574">
+    <nd ref="3144"/>
+    <nd ref="3145"/>
+    <nd ref="3146"/>
+    <nd ref="3147"/>
+    <nd ref="3144"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="575">
+    <nd ref="3148"/>
+    <nd ref="3149"/>
+    <nd ref="3150"/>
+    <nd ref="3151"/>
+    <nd ref="3148"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="576">
+    <nd ref="3152"/>
+    <nd ref="3153"/>
+    <nd ref="3154"/>
+    <nd ref="3155"/>
+    <nd ref="3152"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="577">
+    <nd ref="3156"/>
+    <nd ref="3157"/>
+    <nd ref="3158"/>
+    <nd ref="3159"/>
+    <nd ref="3156"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="578">
+    <nd ref="3160"/>
+    <nd ref="3161"/>
+    <nd ref="3162"/>
+    <nd ref="3163"/>
+    <nd ref="3160"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="579">
+    <nd ref="3164"/>
+    <nd ref="3165"/>
+    <nd ref="3166"/>
+    <nd ref="3167"/>
+    <nd ref="3164"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="580">
+    <nd ref="3168"/>
+    <nd ref="3169"/>
+    <nd ref="3170"/>
+    <nd ref="3171"/>
+    <nd ref="3168"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="581">
+    <nd ref="3172"/>
+    <nd ref="3173"/>
+    <nd ref="3174"/>
+    <nd ref="3175"/>
+    <nd ref="3172"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="582">
+    <nd ref="3176"/>
+    <nd ref="3177"/>
+    <nd ref="3178"/>
+    <nd ref="3179"/>
+    <nd ref="3176"/>
+    <tag k="type" v="pedestrian_marking"/>
+  </way>
+  <way id="9098">
+    <nd ref="1797"/>
+    <nd ref="1717"/>
+    <nd ref="1718"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9104">
+    <nd ref="1710"/>
+    <nd ref="1711"/>
+    <nd ref="1712"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9106">
+    <nd ref="2193"/>
+    <nd ref="2194"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9175">
+    <nd ref="1885"/>
+    <nd ref="1886"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9292">
+    <nd ref="1995"/>
+    <nd ref="1996"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9294">
+    <nd ref="2195"/>
+    <nd ref="2196"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9460">
+    <nd ref="1708"/>
+    <nd ref="1709"/>
+    <nd ref="1710"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9462">
+    <nd ref="1097"/>
+    <nd ref="1095"/>
+    <nd ref="2193"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9490">
+    <nd ref="1996"/>
+    <nd ref="1997"/>
+    <nd ref="1998"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9491">
+    <nd ref="1998"/>
+    <nd ref="1714"/>
+    <nd ref="1708"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9492">
+    <nd ref="2196"/>
+    <nd ref="1098"/>
+    <nd ref="1099"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9493">
+    <nd ref="1099"/>
+    <nd ref="1096"/>
+    <nd ref="1097"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9536">
+    <nd ref="1718"/>
+    <nd ref="1719"/>
+    <nd ref="9535"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9542">
+    <nd ref="9535"/>
+    <nd ref="1720"/>
+    <nd ref="1721"/>
+    <nd ref="1723"/>
+    <nd ref="9541"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9543">
+    <nd ref="9541"/>
+    <nd ref="1724"/>
+    <nd ref="1725"/>
+    <nd ref="1884"/>
+    <nd ref="1885"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10254">
+    <nd ref="1975"/>
+    <nd ref="10253"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10256">
+    <nd ref="2245"/>
+    <nd ref="10255"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10260">
+    <nd ref="10258"/>
+    <nd ref="10259"/>
+    <tag k="type" v="stop_line"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10269">
+    <nd ref="10267"/>
+    <nd ref="10268"/>
+    <tag k="type" v="stop_line"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10285">
+    <nd ref="10277"/>
+    <nd ref="10284"/>
+    <nd ref="10286"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10289">
+    <nd ref="10286"/>
+    <nd ref="10288"/>
+    <nd ref="10290"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10293">
+    <nd ref="10290"/>
+    <nd ref="10292"/>
+    <nd ref="10294"/>
+    <nd ref="10295"/>
+    <nd ref="10296"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10298">
+    <nd ref="10296"/>
+    <nd ref="10297"/>
+    <nd ref="10299"/>
+    <nd ref="10300"/>
+    <nd ref="10301"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10312">
+    <nd ref="2201"/>
+    <nd ref="10311"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10314">
+    <nd ref="1739"/>
+    <nd ref="10313"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10322">
+    <nd ref="1780"/>
+    <nd ref="10321"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10325">
+    <nd ref="10311"/>
+    <nd ref="10324"/>
+    <nd ref="10326"/>
+    <nd ref="10327"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10330">
+    <nd ref="10313"/>
+    <nd ref="10329"/>
+    <nd ref="10331"/>
+    <nd ref="10332"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10368">
+    <nd ref="10362"/>
+    <nd ref="10363"/>
+    <nd ref="10364"/>
+    <nd ref="10365"/>
+    <nd ref="10366"/>
+    <nd ref="10367"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10382">
+    <nd ref="10370"/>
+    <nd ref="10371"/>
+    <nd ref="10372"/>
+    <nd ref="10373"/>
+    <nd ref="10374"/>
+    <nd ref="10375"/>
+    <nd ref="10376"/>
+    <nd ref="10377"/>
+    <nd ref="10378"/>
+    <nd ref="10379"/>
+    <nd ref="10380"/>
+    <nd ref="10381"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10426">
+    <nd ref="10362"/>
+    <nd ref="10384"/>
+    <nd ref="10385"/>
+    <nd ref="10386"/>
+    <nd ref="10387"/>
+    <nd ref="10388"/>
+    <nd ref="10389"/>
+    <nd ref="10390"/>
+    <nd ref="10391"/>
+    <nd ref="10392"/>
+    <nd ref="10393"/>
+    <nd ref="10394"/>
+    <nd ref="10395"/>
+    <nd ref="10396"/>
+    <nd ref="10397"/>
+    <nd ref="10398"/>
+    <nd ref="10399"/>
+    <nd ref="10400"/>
+    <nd ref="10401"/>
+    <nd ref="10402"/>
+    <nd ref="10403"/>
+    <nd ref="10404"/>
+    <nd ref="10381"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10491">
+    <nd ref="10485"/>
+    <nd ref="10486"/>
+    <nd ref="10487"/>
+    <nd ref="10488"/>
+    <nd ref="10489"/>
+    <nd ref="10490"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10608">
+    <nd ref="10473"/>
+    <nd ref="10566"/>
+    <nd ref="10567"/>
+    <nd ref="10568"/>
+    <nd ref="10569"/>
+    <nd ref="10570"/>
+    <nd ref="10571"/>
+    <nd ref="10572"/>
+    <nd ref="10573"/>
+    <nd ref="10574"/>
+    <nd ref="10575"/>
+    <nd ref="10576"/>
+    <nd ref="10577"/>
+    <nd ref="10578"/>
+    <nd ref="10579"/>
+    <nd ref="10580"/>
+    <nd ref="10581"/>
+    <nd ref="10582"/>
+    <nd ref="10583"/>
+    <nd ref="10584"/>
+    <nd ref="10585"/>
+    <nd ref="10586"/>
+    <nd ref="10485"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10648">
+    <nd ref="10636"/>
+    <nd ref="10637"/>
+    <nd ref="10638"/>
+    <nd ref="10639"/>
+    <nd ref="10640"/>
+    <nd ref="10641"/>
+    <nd ref="10642"/>
+    <nd ref="10643"/>
+    <nd ref="10644"/>
+    <nd ref="10645"/>
+    <nd ref="10646"/>
+    <nd ref="10647"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10673">
+    <nd ref="10671"/>
+    <nd ref="10672"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10700">
+    <nd ref="10693"/>
+    <nd ref="10694"/>
+    <nd ref="10695"/>
+    <nd ref="10696"/>
+    <nd ref="10697"/>
+    <nd ref="10698"/>
+    <nd ref="10699"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="10709">
+    <nd ref="10702"/>
+    <nd ref="10703"/>
+    <nd ref="10704"/>
+    <nd ref="10705"/>
+    <nd ref="10706"/>
+    <nd ref="10707"/>
+    <nd ref="10708"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="10753">
+    <nd ref="10647"/>
+    <nd ref="10711"/>
+    <nd ref="10712"/>
+    <nd ref="10713"/>
+    <nd ref="10714"/>
+    <nd ref="10715"/>
+    <nd ref="10716"/>
+    <nd ref="10717"/>
+    <nd ref="10718"/>
+    <nd ref="10719"/>
+    <nd ref="10720"/>
+    <nd ref="10721"/>
+    <nd ref="10722"/>
+    <nd ref="10723"/>
+    <nd ref="10724"/>
+    <nd ref="10725"/>
+    <nd ref="10726"/>
+    <nd ref="10727"/>
+    <nd ref="10728"/>
+    <nd ref="10729"/>
+    <nd ref="10730"/>
+    <nd ref="10731"/>
+    <nd ref="10693"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10798">
+    <nd ref="10708"/>
+    <nd ref="10756"/>
+    <nd ref="10757"/>
+    <nd ref="10758"/>
+    <nd ref="10759"/>
+    <nd ref="10760"/>
+    <nd ref="10761"/>
+    <nd ref="10762"/>
+    <nd ref="10763"/>
+    <nd ref="10764"/>
+    <nd ref="10765"/>
+    <nd ref="10766"/>
+    <nd ref="10767"/>
+    <nd ref="10768"/>
+    <nd ref="10769"/>
+    <nd ref="10770"/>
+    <nd ref="10771"/>
+    <nd ref="10772"/>
+    <nd ref="10773"/>
+    <nd ref="10774"/>
+    <nd ref="10775"/>
+    <nd ref="10776"/>
+    <nd ref="10671"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10836">
+    <nd ref="2173"/>
+    <nd ref="10835"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10838">
+    <nd ref="2048"/>
+    <nd ref="10837"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10842">
+    <nd ref="2053"/>
+    <nd ref="10841"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10845">
+    <nd ref="2165"/>
+    <nd ref="10844"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10847">
+    <nd ref="1788"/>
+    <nd ref="10846"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10851">
+    <nd ref="1569"/>
+    <nd ref="10850"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10862">
+    <nd ref="10860"/>
+    <nd ref="10861"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10866">
+    <nd ref="10864"/>
+    <nd ref="10865"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10873">
+    <nd ref="10868"/>
+    <nd ref="10869"/>
+    <nd ref="10870"/>
+    <nd ref="10871"/>
+    <nd ref="10872"/>
+    <nd ref="10860"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10877">
+    <nd ref="10868"/>
+    <nd ref="10876"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10881">
+    <nd ref="10879"/>
+    <nd ref="10880"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10902">
+    <nd ref="10900"/>
+    <nd ref="10904"/>
+    <nd ref="10901"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10933">
+    <nd ref="10901"/>
+    <nd ref="10905"/>
+    <nd ref="10906"/>
+    <nd ref="10907"/>
+    <nd ref="10908"/>
+    <nd ref="10909"/>
+    <nd ref="10910"/>
+    <nd ref="10911"/>
+    <nd ref="10912"/>
+    <nd ref="10913"/>
+    <nd ref="10914"/>
+    <nd ref="10915"/>
+    <nd ref="10916"/>
+    <nd ref="10917"/>
+    <nd ref="10918"/>
+    <nd ref="10879"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10994">
+    <nd ref="10864"/>
+    <nd ref="10968"/>
+    <nd ref="10969"/>
+    <nd ref="10970"/>
+    <nd ref="10971"/>
+    <nd ref="10972"/>
+    <nd ref="10973"/>
+    <nd ref="10974"/>
+    <nd ref="10975"/>
+    <nd ref="10977"/>
+    <nd ref="10979"/>
+    <nd ref="10980"/>
+    <nd ref="10277"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10997">
+    <nd ref="1569"/>
+    <nd ref="2165"/>
+    <tag k="type" v="stop_line"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11057">
+    <nd ref="11123"/>
+    <nd ref="11056"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11059">
+    <nd ref="11124"/>
+    <nd ref="11058"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11104">
+    <nd ref="1624"/>
+    <nd ref="2182"/>
+    <tag k="type" v="stop_line"/>
+  </way>
+  <way id="11107">
+    <nd ref="1622"/>
+    <nd ref="11106"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="11113">
+    <nd ref="11111"/>
+    <nd ref="11112"/>
+    <tag k="type" v="intersection_coordination"/>
+  </way>
+  <way id="11126">
+    <nd ref="11123"/>
+    <nd ref="11108"/>
+    <nd ref="11010"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11128">
+    <nd ref="11124"/>
+    <nd ref="11109"/>
+    <nd ref="11007"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11130">
+    <nd ref="1624"/>
+    <nd ref="11061"/>
+    <nd ref="11062"/>
+    <nd ref="11063"/>
+    <nd ref="11064"/>
+    <nd ref="11065"/>
+    <nd ref="11066"/>
+    <nd ref="11067"/>
+    <nd ref="11068"/>
+    <nd ref="11069"/>
+    <nd ref="11070"/>
+    <nd ref="11071"/>
+    <nd ref="11072"/>
+    <nd ref="11073"/>
+    <nd ref="11074"/>
+    <nd ref="11075"/>
+    <nd ref="11076"/>
+    <nd ref="11077"/>
+    <nd ref="11078"/>
+    <nd ref="11079"/>
+    <nd ref="11080"/>
+    <nd ref="11009"/>
+    <nd ref="11132"/>
+    <nd ref="11123"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11131">
+    <nd ref="2182"/>
+    <nd ref="11081"/>
+    <nd ref="11082"/>
+    <nd ref="11083"/>
+    <nd ref="11084"/>
+    <nd ref="11085"/>
+    <nd ref="11086"/>
+    <nd ref="11087"/>
+    <nd ref="11088"/>
+    <nd ref="11089"/>
+    <nd ref="11090"/>
+    <nd ref="11091"/>
+    <nd ref="11092"/>
+    <nd ref="11093"/>
+    <nd ref="11094"/>
+    <nd ref="11095"/>
+    <nd ref="11096"/>
+    <nd ref="11097"/>
+    <nd ref="11098"/>
+    <nd ref="11099"/>
+    <nd ref="11100"/>
+    <nd ref="11006"/>
+    <nd ref="11133"/>
+    <nd ref="11124"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="11134">
+    <nd ref="11132"/>
+    <nd ref="11133"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="10265">
+    <nd ref="10261"/>
+    <nd ref="10262"/>
+    <nd ref="10263"/>
+    <nd ref="10264"/>
+    <tag k="type" v="detection_area"/>
+    <tag k="area" v="yes"/>
+  </way>
+  <way id="10803">
+    <nd ref="10473"/>
+    <nd ref="10566"/>
+    <nd ref="10567"/>
+    <nd ref="10568"/>
+    <nd ref="10569"/>
+    <nd ref="10570"/>
+    <nd ref="10571"/>
+    <nd ref="10572"/>
+    <nd ref="10573"/>
+    <nd ref="10574"/>
+    <nd ref="10575"/>
+    <nd ref="10576"/>
+    <nd ref="10577"/>
+    <nd ref="10578"/>
+    <nd ref="10579"/>
+    <nd ref="10580"/>
+    <nd ref="10581"/>
+    <nd ref="10582"/>
+    <nd ref="10583"/>
+    <nd ref="10584"/>
+    <nd ref="10585"/>
+    <nd ref="10586"/>
+    <nd ref="10485"/>
+    <nd ref="1992"/>
+    <nd ref="2176"/>
+    <nd ref="1897"/>
+    <nd ref="10362"/>
+    <nd ref="10384"/>
+    <nd ref="10385"/>
+    <nd ref="10386"/>
+    <nd ref="10387"/>
+    <nd ref="10388"/>
+    <nd ref="10389"/>
+    <nd ref="10390"/>
+    <nd ref="10391"/>
+    <nd ref="10392"/>
+    <nd ref="10393"/>
+    <nd ref="10394"/>
+    <nd ref="10395"/>
+    <nd ref="10396"/>
+    <nd ref="10397"/>
+    <nd ref="10398"/>
+    <nd ref="10399"/>
+    <nd ref="10400"/>
+    <nd ref="10401"/>
+    <nd ref="10402"/>
+    <nd ref="10403"/>
+    <nd ref="10404"/>
+    <nd ref="10381"/>
+    <nd ref="2001"/>
+    <nd ref="2200"/>
+    <nd ref="1890"/>
+    <nd ref="10647"/>
+    <nd ref="10711"/>
+    <nd ref="10712"/>
+    <nd ref="10713"/>
+    <nd ref="10714"/>
+    <nd ref="10715"/>
+    <nd ref="10716"/>
+    <nd ref="10717"/>
+    <nd ref="10718"/>
+    <nd ref="10719"/>
+    <nd ref="10720"/>
+    <nd ref="10721"/>
+    <nd ref="10722"/>
+    <nd ref="10723"/>
+    <nd ref="10724"/>
+    <nd ref="10725"/>
+    <nd ref="10726"/>
+    <nd ref="10727"/>
+    <nd ref="10728"/>
+    <nd ref="10729"/>
+    <nd ref="10730"/>
+    <nd ref="10731"/>
+    <nd ref="10693"/>
+    <nd ref="2007"/>
+    <nd ref="2177"/>
+    <nd ref="1891"/>
+    <nd ref="10708"/>
+    <nd ref="10756"/>
+    <nd ref="10757"/>
+    <nd ref="10758"/>
+    <nd ref="10759"/>
+    <nd ref="10760"/>
+    <nd ref="10761"/>
+    <nd ref="10762"/>
+    <nd ref="10763"/>
+    <nd ref="10764"/>
+    <nd ref="10765"/>
+    <nd ref="10766"/>
+    <nd ref="10767"/>
+    <nd ref="10768"/>
+    <nd ref="10769"/>
+    <nd ref="10770"/>
+    <nd ref="10771"/>
+    <nd ref="10772"/>
+    <nd ref="10773"/>
+    <nd ref="10774"/>
+    <nd ref="10775"/>
+    <nd ref="10776"/>
+    <nd ref="10671"/>
+    <nd ref="1995"/>
+    <nd ref="2195"/>
+    <nd ref="1886"/>
+    <tag k="type" v="intersection_area"/>
+    <tag k="area" v="yes"/>
+  </way>
+  <way id="10998">
+    <nd ref="10868"/>
+    <nd ref="10869"/>
+    <nd ref="10870"/>
+    <nd ref="10871"/>
+    <nd ref="10872"/>
+    <nd ref="10860"/>
+    <nd ref="2048"/>
+    <nd ref="2173"/>
+    <nd ref="2053"/>
+    <nd ref="10864"/>
+    <nd ref="10968"/>
+    <nd ref="10969"/>
+    <nd ref="10970"/>
+    <nd ref="10971"/>
+    <nd ref="10972"/>
+    <nd ref="10973"/>
+    <nd ref="10974"/>
+    <nd ref="10975"/>
+    <nd ref="10977"/>
+    <nd ref="10979"/>
+    <nd ref="10980"/>
+    <nd ref="10277"/>
+    <nd ref="1797"/>
+    <nd ref="2194"/>
+    <nd ref="1712"/>
+    <nd ref="10901"/>
+    <nd ref="10905"/>
+    <nd ref="10906"/>
+    <nd ref="10907"/>
+    <nd ref="10908"/>
+    <nd ref="10909"/>
+    <nd ref="10910"/>
+    <nd ref="10911"/>
+    <nd ref="10912"/>
+    <nd ref="10913"/>
+    <nd ref="10914"/>
+    <nd ref="10915"/>
+    <nd ref="10916"/>
+    <nd ref="10917"/>
+    <nd ref="10918"/>
+    <nd ref="10879"/>
+    <nd ref="1788"/>
+    <nd ref="2165"/>
+    <nd ref="1569"/>
+    <tag k="type" v="intersection_area"/>
+    <tag k="area" v="yes"/>
+  </way>
+  <way id="10274">
+    <nd ref="10270"/>
+    <nd ref="10271"/>
+    <nd ref="10272"/>
+    <nd ref="10273"/>
+    <tag k="type" v="no_stopping_area"/>
+    <tag k="area" v="yes"/>
+  </way>
+  <relation id="13">
+    <member type="way" role="left" ref="245"/>
+    <member type="way" role="right" ref="248"/>
+    <member type="relation" role="regulatory_element" ref="1024"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="14">
+    <member type="way" role="left" ref="247"/>
+    <member type="way" role="right" ref="248"/>
+    <member type="relation" role="regulatory_element" ref="1025"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="15">
+    <member type="way" role="left" ref="249"/>
+    <member type="way" role="right" ref="250"/>
+    <member type="relation" role="regulatory_element" ref="1024"/>
+    <member type="relation" role="regulatory_element" ref="11140"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="16">
+    <member type="way" role="left" ref="251"/>
+    <member type="way" role="right" ref="250"/>
+    <member type="relation" role="regulatory_element" ref="1026"/>
+    <member type="relation" role="regulatory_element" ref="11141"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="17">
+    <member type="way" role="left" ref="253"/>
+    <member type="way" role="right" ref="256"/>
+    <member type="relation" role="regulatory_element" ref="1025"/>
+    <member type="relation" role="regulatory_element" ref="11139"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="18">
+    <member type="way" role="left" ref="255"/>
+    <member type="way" role="right" ref="256"/>
+    <member type="relation" role="regulatory_element" ref="1026"/>
+    <member type="relation" role="regulatory_element" ref="11142"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10998"/>
+  </relation>
+  <relation id="49">
+    <member type="way" role="left" ref="197"/>
+    <member type="way" role="right" ref="204"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="50">
+    <member type="way" role="left" ref="199"/>
+    <member type="way" role="right" ref="218"/>
+    <member type="relation" role="regulatory_element" ref="1012"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="10353"/>
+    <member type="relation" role="regulatory_element" ref="11149"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="51">
+    <member type="way" role="left" ref="201"/>
+    <member type="way" role="right" ref="202"/>
+    <member type="relation" role="regulatory_element" ref="1012"/>
+    <member type="relation" role="regulatory_element" ref="10353"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <member type="relation" role="regulatory_element" ref="11145"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="52">
+    <member type="way" role="left" ref="203"/>
+    <member type="way" role="right" ref="204"/>
+    <member type="relation" role="regulatory_element" ref="1015"/>
+    <member type="relation" role="regulatory_element" ref="10334"/>
+    <member type="relation" role="regulatory_element" ref="10353"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="53">
+    <member type="way" role="left" ref="205"/>
+    <member type="way" role="right" ref="206"/>
+    <member type="relation" role="regulatory_element" ref="1015"/>
+    <member type="relation" role="regulatory_element" ref="10334"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="11143"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="54">
+    <member type="way" role="left" ref="207"/>
+    <member type="way" role="right" ref="214"/>
+    <member type="relation" role="regulatory_element" ref="1015"/>
+    <member type="relation" role="regulatory_element" ref="10275"/>
+    <member type="relation" role="regulatory_element" ref="10334"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <member type="relation" role="regulatory_element" ref="11147"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="55">
+    <member type="way" role="left" ref="209"/>
+    <member type="way" role="right" ref="210"/>
+    <member type="relation" role="regulatory_element" ref="1018"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="56">
+    <member type="way" role="left" ref="211"/>
+    <member type="way" role="right" ref="202"/>
+    <member type="relation" role="regulatory_element" ref="1018"/>
+    <member type="relation" role="regulatory_element" ref="10353"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <member type="relation" role="regulatory_element" ref="11150"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="57">
+    <member type="way" role="left" ref="213"/>
+    <member type="way" role="right" ref="214"/>
+    <member type="relation" role="regulatory_element" ref="1018"/>
+    <member type="relation" role="regulatory_element" ref="10334"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <member type="relation" role="regulatory_element" ref="11146"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="58">
+    <member type="way" role="left" ref="215"/>
+    <member type="way" role="right" ref="210"/>
+    <member type="relation" role="regulatory_element" ref="1021"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="10360"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="straight"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="59">
+    <member type="way" role="left" ref="217"/>
+    <member type="way" role="right" ref="218"/>
+    <member type="relation" role="regulatory_element" ref="1021"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="10353"/>
+    <member type="relation" role="regulatory_element" ref="11144"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="60">
+    <member type="way" role="left" ref="219"/>
+    <member type="way" role="right" ref="206"/>
+    <member type="relation" role="regulatory_element" ref="1021"/>
+    <member type="relation" role="regulatory_element" ref="10334"/>
+    <member type="relation" role="regulatory_element" ref="10341"/>
+    <member type="relation" role="regulatory_element" ref="11148"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="right"/>
+    <tag k="intersection_area" v="10803"/>
+  </relation>
+  <relation id="112">
+    <member type="way" role="left" ref="35"/>
+    <member type="way" role="right" ref="38"/>
+    <member type="relation" role="regulatory_element" ref="10266"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="113">
+    <member type="way" role="left" ref="37"/>
+    <member type="way" role="right" ref="38"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="116">
+    <member type="way" role="left" ref="9292"/>
+    <member type="way" role="right" ref="9294"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="122">
+    <member type="way" role="left" ref="41"/>
+    <member type="way" role="right" ref="42"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="fms_lane_passable" v="false"/>
+  </relation>
+  <relation id="123">
+    <member type="way" role="left" ref="39"/>
+    <member type="way" role="right" ref="42"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="124">
+    <member type="way" role="left" ref="43"/>
+    <member type="way" role="right" ref="46"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="fms_lane_passable" v="false"/>
+  </relation>
+  <relation id="125">
+    <member type="way" role="left" ref="45"/>
+    <member type="way" role="right" ref="46"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="163">
+    <member type="way" role="left" ref="325"/>
+    <member type="way" role="right" ref="326"/>
+    <member type="relation" role="regulatory_element" ref="9918"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="crosswalk"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="participant:pedestrian" v="yes"/>
+  </relation>
+  <relation id="164">
+    <member type="way" role="left" ref="327"/>
+    <member type="way" role="right" ref="328"/>
+    <member type="relation" role="regulatory_element" ref="9896"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="crosswalk"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="participant:pedestrian" v="yes"/>
+  </relation>
+  <relation id="165">
+    <member type="way" role="left" ref="329"/>
+    <member type="way" role="right" ref="330"/>
+    <member type="relation" role="regulatory_element" ref="9874"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="crosswalk"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="participant:pedestrian" v="yes"/>
+  </relation>
+  <relation id="166">
+    <member type="way" role="left" ref="331"/>
+    <member type="way" role="right" ref="332"/>
+    <member type="relation" role="regulatory_element" ref="9838"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="crosswalk"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="participant:pedestrian" v="yes"/>
+  </relation>
+  <relation id="9102">
+    <member type="way" role="left" ref="9536"/>
+    <member type="way" role="right" ref="9462"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9107">
+    <member type="way" role="left" ref="9104"/>
+    <member type="way" role="right" ref="9106"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9178">
+    <member type="way" role="left" ref="9175"/>
+    <member type="way" role="right" ref="9294"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9183">
+    <member type="way" role="left" ref="9490"/>
+    <member type="way" role="right" ref="9492"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9297">
+    <member type="way" role="left" ref="9098"/>
+    <member type="way" role="right" ref="9106"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9463">
+    <member type="way" role="left" ref="9460"/>
+    <member type="way" role="right" ref="9462"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9494">
+    <member type="way" role="left" ref="9491"/>
+    <member type="way" role="right" ref="9493"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9540">
+    <member type="way" role="left" ref="9542"/>
+    <member type="way" role="right" ref="9493"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="9546">
+    <member type="way" role="left" ref="9543"/>
+    <member type="way" role="right" ref="9492"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10257">
+    <member type="way" role="left" ref="10254"/>
+    <member type="way" role="right" ref="10256"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10287">
+    <member type="way" role="left" ref="10285"/>
+    <member type="way" role="right" ref="9098"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10291">
+    <member type="way" role="left" ref="10289"/>
+    <member type="way" role="right" ref="9536"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10303">
+    <member type="way" role="left" ref="10293"/>
+    <member type="way" role="right" ref="9542"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10304">
+    <member type="way" role="left" ref="10298"/>
+    <member type="way" role="right" ref="9543"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10316">
+    <member type="way" role="left" ref="10314"/>
+    <member type="way" role="right" ref="10312"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10323">
+    <member type="way" role="left" ref="10322"/>
+    <member type="way" role="right" ref="10312"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10333">
+    <member type="way" role="left" ref="10330"/>
+    <member type="way" role="right" ref="10325"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10839">
+    <member type="way" role="left" ref="10838"/>
+    <member type="way" role="right" ref="10836"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10843">
+    <member type="way" role="left" ref="10842"/>
+    <member type="way" role="right" ref="10836"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10848">
+    <member type="way" role="left" ref="10847"/>
+    <member type="way" role="right" ref="10845"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10852">
+    <member type="way" role="left" ref="10851"/>
+    <member type="way" role="right" ref="10845"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="11060">
+    <member type="way" role="left" ref="11057"/>
+    <member type="way" role="right" ref="11059"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="11103">
+    <member type="way" role="left" ref="11130"/>
+    <member type="way" role="right" ref="11131"/>
+    <member type="relation" role="regulatory_element" ref="11136"/>
+    <member type="relation" role="regulatory_element" ref="11138"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+    <tag k="turn_direction" v="left"/>
+  </relation>
+  <relation id="11129">
+    <member type="way" role="left" ref="11126"/>
+    <member type="way" role="right" ref="11128"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="1012">
+    <member type="way" role="refers" ref="369"/>
+    <member type="way" role="refers" ref="371"/>
+    <member type="way" role="refers" ref="373"/>
+    <member type="way" role="ref_line" ref="367"/>
+    <member type="way" role="light_bulbs" ref="368"/>
+    <member type="way" role="light_bulbs" ref="370"/>
+    <member type="way" role="light_bulbs" ref="372"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1015">
+    <member type="way" role="refers" ref="380"/>
+    <member type="way" role="refers" ref="382"/>
+    <member type="way" role="refers" ref="384"/>
+    <member type="way" role="ref_line" ref="378"/>
+    <member type="way" role="light_bulbs" ref="379"/>
+    <member type="way" role="light_bulbs" ref="381"/>
+    <member type="way" role="light_bulbs" ref="383"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1018">
+    <member type="way" role="refers" ref="391"/>
+    <member type="way" role="refers" ref="393"/>
+    <member type="way" role="refers" ref="395"/>
+    <member type="way" role="ref_line" ref="389"/>
+    <member type="way" role="light_bulbs" ref="390"/>
+    <member type="way" role="light_bulbs" ref="392"/>
+    <member type="way" role="light_bulbs" ref="394"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1021">
+    <member type="way" role="refers" ref="402"/>
+    <member type="way" role="refers" ref="404"/>
+    <member type="way" role="refers" ref="406"/>
+    <member type="way" role="ref_line" ref="400"/>
+    <member type="way" role="light_bulbs" ref="401"/>
+    <member type="way" role="light_bulbs" ref="403"/>
+    <member type="way" role="light_bulbs" ref="405"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1024">
+    <member type="way" role="refers" ref="413"/>
+    <member type="way" role="ref_line" ref="411"/>
+    <member type="way" role="light_bulbs" ref="412"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1025">
+    <member type="way" role="refers" ref="416"/>
+    <member type="way" role="ref_line" ref="10997"/>
+    <member type="way" role="light_bulbs" ref="415"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="1026">
+    <member type="way" role="refers" ref="419"/>
+    <member type="way" role="ref_line" ref="417"/>
+    <member type="way" role="light_bulbs" ref="418"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="9838">
+    <member type="way" role="refers" ref="410"/>
+    <member type="way" role="refers" ref="375"/>
+    <member type="way" role="light_bulbs" ref="409"/>
+    <member type="way" role="light_bulbs" ref="374"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="9874">
+    <member type="way" role="refers" ref="377"/>
+    <member type="way" role="refers" ref="397"/>
+    <member type="way" role="light_bulbs" ref="376"/>
+    <member type="way" role="light_bulbs" ref="396"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="9896">
+    <member type="way" role="refers" ref="399"/>
+    <member type="way" role="refers" ref="386"/>
+    <member type="way" role="light_bulbs" ref="398"/>
+    <member type="way" role="light_bulbs" ref="385"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="9918">
+    <member type="way" role="refers" ref="388"/>
+    <member type="way" role="refers" ref="408"/>
+    <member type="way" role="light_bulbs" ref="387"/>
+    <member type="way" role="light_bulbs" ref="407"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="10266">
+    <member type="way" role="refers" ref="10265"/>
+    <member type="way" role="ref_line" ref="10260"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="detection_area"/>
+  </relation>
+  <relation id="10275">
+    <member type="way" role="refers" ref="10274"/>
+    <member type="way" role="ref_line" ref="10269"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="no_stopping_area"/>
+  </relation>
+  <relation id="10334">
+    <member type="relation" role="refers" ref="164"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="crosswalk"/>
+  </relation>
+  <relation id="10341">
+    <member type="relation" role="refers" ref="163"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="crosswalk"/>
+  </relation>
+  <relation id="10353">
+    <member type="relation" role="refers" ref="166"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="crosswalk"/>
+  </relation>
+  <relation id="10360">
+    <member type="relation" role="refers" ref="165"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="crosswalk"/>
+  </relation>
+  <relation id="11136">
+    <member type="way" role="refers" ref="11113"/>
+    <member type="way" role="ref_line" ref="11104"/>
+    <member type="way" role="start_line" ref="11107"/>
+    <member type="way" role="end_line" ref="11134"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="virtual_traffic_light"/>
+  </relation>
+  <relation id="11138">
+    <member type="relation" role="right_of_way" ref="11103"/>
+    <member type="relation" role="yield" ref="11060"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11139">
+    <member type="relation" role="right_of_way" ref="17"/>
+    <member type="relation" role="yield" ref="16"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11140">
+    <member type="relation" role="right_of_way" ref="15"/>
+    <member type="relation" role="yield" ref="17"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11141">
+    <member type="relation" role="right_of_way" ref="16"/>
+    <member type="relation" role="yield" ref="17"/>
+    <member type="relation" role="yield" ref="14"/>
+    <member type="relation" role="yield" ref="13"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11142">
+    <member type="relation" role="right_of_way" ref="18"/>
+    <member type="relation" role="yield" ref="13"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11143">
+    <member type="relation" role="right_of_way" ref="53"/>
+    <member type="relation" role="yield" ref="50"/>
+    <member type="relation" role="yield" ref="55"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11144">
+    <member type="relation" role="right_of_way" ref="59"/>
+    <member type="relation" role="yield" ref="56"/>
+    <member type="relation" role="yield" ref="52"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11145">
+    <member type="relation" role="right_of_way" ref="51"/>
+    <member type="relation" role="yield" ref="58"/>
+    <member type="relation" role="yield" ref="54"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11146">
+    <member type="relation" role="right_of_way" ref="57"/>
+    <member type="relation" role="yield" ref="49"/>
+    <member type="relation" role="yield" ref="60"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11147">
+    <member type="relation" role="right_of_way" ref="54"/>
+    <member type="relation" role="yield" ref="55"/>
+    <member type="relation" role="yield" ref="58"/>
+    <member type="relation" role="yield" ref="60"/>
+    <member type="relation" role="yield" ref="56"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11148">
+    <member type="relation" role="right_of_way" ref="60"/>
+    <member type="relation" role="yield" ref="49"/>
+    <member type="relation" role="yield" ref="52"/>
+    <member type="relation" role="yield" ref="54"/>
+    <member type="relation" role="yield" ref="50"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11149">
+    <member type="relation" role="right_of_way" ref="50"/>
+    <member type="relation" role="yield" ref="55"/>
+    <member type="relation" role="yield" ref="58"/>
+    <member type="relation" role="yield" ref="60"/>
+    <member type="relation" role="yield" ref="56"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+  <relation id="11150">
+    <member type="relation" role="right_of_way" ref="56"/>
+    <member type="relation" role="yield" ref="49"/>
+    <member type="relation" role="yield" ref="52"/>
+    <member type="relation" role="yield" ref="50"/>
+    <member type="relation" role="yield" ref="54"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="right_of_way"/>
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/data/map/sample_map.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/sample_map.osm
@@ -5323,7 +5323,7 @@
 		<nd ref="1795" />
 		<nd ref="1787" />
 		<nd ref="1788" />
-		<tag k="type" v="line_thin" />
+		<tag k="type" v="virtual" />
 		<tag k="subtype" v="solid" />
 		<tag k="width" v="0.200" />
 	</way>
@@ -5334,7 +5334,7 @@
 		<nd ref="1571" />
 		<nd ref="2049" />
 		<nd ref="2048" />
-		<tag k="type" v="line_thin" />
+		<tag k="type" v="virtual" />
 		<tag k="subtype" v="solid" />
 		<tag k="width" v="0.200" />
 	</way>

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
@@ -1,0 +1,78 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/utils.hpp"
+#include "lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp"
+#include "map_validation_tester.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <string>
+
+class TestIntersectionLaneletBorderTypeValidator : public MapValidationTester
+{
+protected:
+  const std::string test_target_ =
+    std::string(lanelet::autoware::validation::IntersectionLaneletBorderTypeValidator::name());
+};
+
+TEST_F(TestIntersectionLaneletBorderTypeValidator, ValidatorAvailability)  // NOLINT for gtest
+{
+  std::string expected_validator_name =
+    lanelet::autoware::validation::IntersectionLaneletBorderTypeValidator::name();
+
+  lanelet::validation::Strings validators =
+    lanelet::validation::availabeChecks(expected_validator_name);  // cspell:disable-line
+
+  const uint32_t expected_validator_num = 1;
+  EXPECT_EQ(expected_validator_num, validators.size());
+  EXPECT_EQ(expected_validator_name, validators[0]);
+}
+
+TEST_F(TestIntersectionLaneletBorderTypeValidator, InvalidBorderType)  // NOLINT for gtest
+{
+  load_target_map("intersection/intersection_lanelet_invalid_border_type.osm");
+
+  lanelet::autoware::validation::IntersectionLaneletBorderTypeValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 1);
+
+  const lanelet::Id expected_lanelet_id_1 = 13;
+  const auto expected_issue_1 =
+    construct_issue_from_code(issue_code(test_target_, 1), expected_lanelet_id_1);
+  
+  bool found_lanelet_13 = false;
+  for (const auto & issue : issues) {
+    if (issue.id == expected_lanelet_id_1) {
+      found_lanelet_13 = true;
+      const auto difference = compare_an_issue(expected_issue_1, issue);
+      EXPECT_TRUE(difference.empty()) << difference;
+      EXPECT_EQ(issue.id, expected_lanelet_id_1) << "Issue should be for lanelet ID 13";
+      break;
+    }
+  }
+  EXPECT_TRUE(found_lanelet_13) << "Should find issue for lanelet 13";
+}
+
+TEST_F(TestIntersectionLaneletBorderTypeValidator, ValidConfiguration)  // NOLINT for gtest
+{
+  load_target_map("sample_map.osm");
+
+  lanelet::autoware::validation::IntersectionLaneletBorderTypeValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0) << "sample_map.osm should pass intersection lanelet border type validation";
+}

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
@@ -53,7 +53,7 @@ TEST_F(TestIntersectionLaneletBorderTypeValidator, InvalidBorderType)  // NOLINT
   const lanelet::Id expected_lanelet_id_1 = 13;
   const auto expected_issue_1 =
     construct_issue_from_code(issue_code(test_target_, 1), expected_lanelet_id_1);
-  
+
   bool found_lanelet_13 = false;
   for (const auto & issue : issues) {
     if (issue.id == expected_lanelet_id_1) {
@@ -74,5 +74,6 @@ TEST_F(TestIntersectionLaneletBorderTypeValidator, ValidConfiguration)  // NOLIN
   lanelet::autoware::validation::IntersectionLaneletBorderTypeValidator checker;
   const auto & issues = checker(*map_);
 
-  EXPECT_EQ(issues.size(), 0) << "sample_map.osm should pass intersection lanelet border type validation";
+  EXPECT_EQ(issues.size(), 0)
+    << "sample_map.osm should pass intersection lanelet border type validation";
 }

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_lanelet_border_type.cpp
@@ -50,21 +50,18 @@ TEST_F(TestIntersectionLaneletBorderTypeValidator, InvalidBorderType)  // NOLINT
 
   EXPECT_EQ(issues.size(), 1);
 
-  const lanelet::Id expected_lanelet_id_1 = 13;
-  const auto expected_issue_1 =
-    construct_issue_from_code(issue_code(test_target_, 1), expected_lanelet_id_1);
+  const lanelet::Id expected_lanelet_id = 13;
+  const auto expected_issue =
+    construct_issue_from_code(issue_code(test_target_, 1), expected_lanelet_id);
 
-  bool found_lanelet_13 = false;
   for (const auto & issue : issues) {
-    if (issue.id == expected_lanelet_id_1) {
-      found_lanelet_13 = true;
-      const auto difference = compare_an_issue(expected_issue_1, issue);
+    if (issue.id == expected_lanelet_id) {
+      const auto difference = compare_an_issue(expected_issue, issue);
       EXPECT_TRUE(difference.empty()) << difference;
-      EXPECT_EQ(issue.id, expected_lanelet_id_1) << "Issue should be for lanelet ID 13";
+      EXPECT_EQ(issue.id, expected_lanelet_id) << "Issue should be for lanelet ID 13";
       break;
     }
   }
-  EXPECT_TRUE(found_lanelet_13) << "Should find issue for lanelet 13";
 }
 
 TEST_F(TestIntersectionLaneletBorderTypeValidator, ValidConfiguration)  // NOLINT for gtest


### PR DESCRIPTION
## Description

This PR introduces a new validator: `mapping.intersection.lanelet_border_type`.
Its purpose is to ensure that lanelets tagged with `intersection_area` have both LeftBound and RightBound of type `"virtual"` or `"road_border"` as required by [VM-03-02 specification](https://docs.pilot.auto/en/reference-design/common/map-requirements/vector-map-requirements/category_intersection/#vm-03-02-lanelets-turn-direction-and-virtual).

### Validation subjects:

Lanelets that have the `intersection_area` tag

### What is validated:

* Whether the `LeftBound` and `RightBound` of the lanelet are of type `"virtual"` or `"road_border"`

### Added files:

* `autoware_lanelet2_map_validator/include/lanelet2_map_validator/validators/intersection/intersection_lanelet_border_type.hpp`
* `autoware_lanelet2_map_validator/src/validators/intersection/intersection_lanelet_border_type.cpp`
* `autoware_lanelet2_map_validator/docs/intersection/intersection_lanelet_border_type.md`
* `autoware_lanelet2_map_validator/test/test_maps/intersection_lanelet_invalid_border_type.osm`

### Modified files:

* `autoware_lanelet2_map_validator/test/test_maps/sample_map.osm`

  * Line 5326, 5337: updated the `type` of the linestrings to `"virtual"` to comply with validation

* `autoware_lanelet2_map_validator/config/issues_info.json`

  * Added issue code `Intersection.VirtualBorderType-001` for this validator

### Output Example

> Error: [lanelet 13](element://Lanelet/13) [Intersection.LaneletBorderType-001] The LeftBound and RightBound of lanelet with intersection_area tag must be either virtual or road_border type. [mapping.intersection.lanelet_border_type]

## How was this PR tested?

unit test with new map
* `intersection_lanelet_invalid_border_type.osm` -> lanelet 13 "left" type is not "virtual"` or `"road_border"`

## Notes for reviewers

None.

## Effects on system behavior
