### PR TITLE
feat(stop_line): added validator for lateral connection lanelet subtypes (vm-01-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Then you will see `lanelet2_validation_results.json` in your current working dir
   - `autoware_requirement_set.json` is the most general file for Autoware if you don't have any specifications.
 - `lanelet2_validation_results.json` will be overwritten if it already exists!!
 - The following tab will be appended to the lanelet2 map (`.osm` file). This tab shouldn't harm the Autoware behaviour.
+
   - All information will be generated automatically. The `validator_version` is obtained from the `package.xml` and the `requirements_version` is obtained from the requirement set JSON file.
 
   ```xml

--- a/README_ja.md
+++ b/README_ja.md
@@ -143,6 +143,7 @@ ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator \
   - 特に指定の要求仕様リストがなければ Autoware の地図仕様に即した `autoware_lanelet2_map_validator` を使ってください。
 - `lanelet2_validation_results.json` が既に存在する場合は上書きされてしまいます。
 - 下記のようなタブが Lanelet2 地図 (`osm` ファイル) に追記されます。このタブは Autoware の挙動に影響はしません。
+
   - 本タブの情報は自動的に付与されるもので、何か手入力する必要はありません。`validation_version` は `package.xml` から、`requirements_version` は要求仕様リストから取得されます。
 
   ```xml

--- a/autoware_lanelet2_map_validator/config/issues_info.json
+++ b/autoware_lanelet2_map_validator/config/issues_info.json
@@ -454,5 +454,13 @@
       "en": "Attribute participant:pedestrian of refers is not set to \"yes\" or \"true\".",
       "ja": "refers lanelet のタグ participant:pedestrian が \"yes\" か \"true\" に設定されていません。"
     }
+  },
+  "Lane.LateralSubtypeConnection-001": {
+    "severity": "Error",
+    "primitive": "lanelet",
+    "message": {
+      "en": "Adjacent lanelet {adjacent_lanelet_id} has incompatible subtype for linestring sharing.",
+      "ja": "隣接する lanelet {adjacent_lanelet_id} は linestring 共有に互換性のない subtype。"
+    }
   }
 }

--- a/autoware_lanelet2_map_validator/docs/intersection/lateral_subtype_connection.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/lateral_subtype_connection.md
@@ -9,13 +9,14 @@ mapping.lane.lateral_subtype_connection
 This validator ensures that adjacent lanelets have compatible subtypes for vehicle navigation. It checks that laterally adjacent lanelets (left and right) have subtypes that are suitable for vehicle traffic, preventing incompatible lane adjacencies that could cause routing or navigation issues.
 
 The validator specifically focuses on:
+
 - Checking left and right adjacent lanelets using the routing graph
 - Ensuring adjacent lanelets have vehicle-suitable subtypes
 - Preventing adjacency between vehicle lanes and non-vehicle-suitable lane types
 
-| Issue Code | Message | Severity | Primitive | Description | Approach |
-| ---------- | ------- | -------- | --------- | ----------- | -------- |
-| Lane.LateralSubtypeConnection-001 | Adjacent lanelet {adjacent_lanelet_id} has incompatible subtype for vehicle traffic | Error | lanelet | A lanelet is adjacent to another lanelet with an incompatible subtype. Vehicle-suitable subtypes include "road", "road_shoulder", and "pedestrian_lane". | Verify that adjacent lanelets have compatible subtypes. If one lanelet is not suitable for vehicles, they should not be laterally adjacent. |
+| Issue Code                        | Message                                                                             | Severity | Primitive | Description                                                                                                                                              | Approach                                                                                                                                    |
+| --------------------------------- | ----------------------------------------------------------------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lane.LateralSubtypeConnection-001 | Adjacent lanelet {adjacent_lanelet_id} has incompatible subtype for vehicle traffic | Error    | lanelet   | A lanelet is adjacent to another lanelet with an incompatible subtype. Vehicle-suitable subtypes include "road", "road_shoulder", and "pedestrian_lane". | Verify that adjacent lanelets have compatible subtypes. If one lanelet is not suitable for vehicles, they should not be laterally adjacent. |
 
 ## Parameters
 
@@ -33,6 +34,7 @@ None.
 ### Vehicle-Suitable Subtypes
 
 The validator considers the following subtypes as vehicle-suitable:
+
 - `road` (default when no subtype is specified)
 - `road_shoulder`
 - `pedestrian_lane`
@@ -40,6 +42,7 @@ The validator considers the following subtypes as vehicle-suitable:
 ### Error Detection
 
 An error is reported when:
+
 - A lanelet with a vehicle-suitable subtype is adjacent to a lanelet with a non-vehicle-suitable subtype
 - The adjacency relationship is determined by the routing graph's `adjacentLeft()` and `adjacentRight()` methods
 

--- a/autoware_lanelet2_map_validator/docs/intersection/lateral_subtype_connection.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/lateral_subtype_connection.md
@@ -1,0 +1,49 @@
+# lateral_subtype_connection
+
+## Validator name
+
+mapping.lane.lateral_subtype_connection
+
+## Feature
+
+This validator ensures that adjacent lanelets have compatible subtypes for vehicle navigation. It checks that laterally adjacent lanelets (left and right) have subtypes that are suitable for vehicle traffic, preventing incompatible lane adjacencies that could cause routing or navigation issues.
+
+The validator specifically focuses on:
+- Checking left and right adjacent lanelets using the routing graph
+- Ensuring adjacent lanelets have vehicle-suitable subtypes
+- Preventing adjacency between vehicle lanes and non-vehicle-suitable lane types
+
+| Issue Code | Message | Severity | Primitive | Description | Approach |
+| ---------- | ------- | -------- | --------- | ----------- | -------- |
+| Lane.LateralSubtypeConnection-001 | Adjacent lanelet {adjacent_lanelet_id} has incompatible subtype for vehicle traffic | Error | lanelet | A lanelet is adjacent to another lanelet with an incompatible subtype. Vehicle-suitable subtypes include "road", "road_shoulder", and "pedestrian_lane". | Verify that adjacent lanelets have compatible subtypes. If one lanelet is not suitable for vehicles, they should not be laterally adjacent. |
+
+## Parameters
+
+None.
+
+## Implementation Details
+
+### Algorithm
+
+1. **Routing Graph Creation**: Creates a routing graph using vehicle traffic rules to identify adjacent relationships
+2. **Adjacent Lanelet Detection**: For each lanelet in the map, finds left and right adjacent lanelets using the routing graph
+3. **Subtype Validation**: Checks if both the current lanelet and adjacent lanelet have vehicle-suitable subtypes
+4. **Duplicate Prevention**: Uses a set of processed pairs to avoid checking the same adjacency relationship twice
+
+### Vehicle-Suitable Subtypes
+
+The validator considers the following subtypes as vehicle-suitable:
+- `road` (default when no subtype is specified)
+- `road_shoulder`
+- `pedestrian_lane`
+
+### Error Detection
+
+An error is reported when:
+- A lanelet with a vehicle-suitable subtype is adjacent to a lanelet with a non-vehicle-suitable subtype
+- The adjacency relationship is determined by the routing graph's `adjacentLeft()` and `adjacentRight()` methods
+
+## Related source codes
+
+- lateral_subtype_connection.cpp
+- lateral_subtype_connection.hpp

--- a/autoware_lanelet2_map_validator/gui/README.md
+++ b/autoware_lanelet2_map_validator/gui/README.md
@@ -93,19 +93,23 @@ The built executable in `./dist/map_validator_gui` can be distributed to other s
 ### Basic Workflow
 
 1. **Load a Map**:
+
    - Click "Browse" next to "OSM File" or drag & drop an `.osm` file
    - The map will automatically load in the visualization tab
 
 2. **Select Validators**:
+
    - Choose from the list of available validators on the left panel
    - Or use "Manual regex input" for custom validator filtering
 
 3. **Configure Options** (Optional):
+
    - Set projector type (MGRS, UTM, Transverse Mercator)
    - Choose language (English or Japanese)
    - Add requirement files, exclusion lists, or parameter files
 
 4. **Run Validation**:
+
    - Click "Run Validator" button
    - Results will appear in the Errors/Warnings tabs
 

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/lateral_subtype_connection.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/intersection/lateral_subtype_connection.hpp
@@ -1,0 +1,36 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__LATERAL_SUBTYPE_CONNECTION_HPP_
+#define LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__LATERAL_SUBTYPE_CONNECTION_HPP_
+
+#include <lanelet2_validation/Validation.h>
+#include <lanelet2_validation/ValidatorFactory.h>
+
+namespace lanelet::autoware::validation
+{
+class LateralSubtypeConnectionValidator : public lanelet::validation::MapValidator
+{
+public:
+  // Write the validator's name here
+  constexpr static const char * name() { return "mapping.lane.lateral_subtype_connection"; }
+
+  lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
+
+private:
+  lanelet::validation::Issues check_lateral_subtype_connection(const lanelet::LaneletMap & map);
+};
+}  // namespace lanelet::autoware::validation
+
+#endif  // LANELET2_MAP_VALIDATOR__VALIDATORS__INTERSECTION__LATERAL_SUBTYPE_CONNECTION_HPP_

--- a/autoware_lanelet2_map_validator/src/validators/intersection/lateral_subtype_connection.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/lateral_subtype_connection.cpp
@@ -37,7 +37,6 @@ void check_adjacent_subtype_compatibility(
   std::set<std::pair<lanelet::Id, lanelet::Id>> & processed_pairs,
   lanelet::validation::Issues & issues, const std::string & validator_name)
 {
-  // Avoid duplicate processing of the same pair
   std::pair<lanelet::Id, lanelet::Id> current_pair = {current_lane.id(), adjacent_lane.id()};
   std::pair<lanelet::Id, lanelet::Id> reverse_pair = {adjacent_lane.id(), current_lane.id()};
   if (processed_pairs.count(current_pair) || processed_pairs.count(reverse_pair)) {
@@ -90,14 +89,12 @@ lanelet::validation::Issues LateralSubtypeConnectionValidator::check_lateral_sub
   std::set<std::pair<lanelet::Id, lanelet::Id>> processed_pairs;
 
   for (const lanelet::ConstLanelet & lane : map.laneletLayer) {
-    // Check left adjacent lanelet
     const auto left_adjacent = routing_graph_ptr->adjacentLeft(lane);
     if (left_adjacent) {
       check_adjacent_subtype_compatibility(
         lane, left_adjacent.get(), processed_pairs, issues, this->name());
     }
 
-    // Check right adjacent lanelet
     const auto right_adjacent = routing_graph_ptr->adjacentRight(lane);
     if (right_adjacent) {
       check_adjacent_subtype_compatibility(

--- a/autoware_lanelet2_map_validator/src/validators/intersection/lateral_subtype_connection.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/lateral_subtype_connection.cpp
@@ -1,0 +1,105 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/intersection/lateral_subtype_connection.hpp"
+
+#include "lanelet2_map_validator/utils.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LaneletMap.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace lanelet::autoware::validation
+{
+namespace
+{
+lanelet::validation::RegisterMapValidator<LateralSubtypeConnectionValidator> reg;
+
+void check_adjacent_subtype_compatibility(
+  const lanelet::ConstLanelet & current_lane,
+  const lanelet::ConstLanelet & adjacent_lane,
+  std::set<std::pair<lanelet::Id, lanelet::Id>> & processed_pairs,
+  lanelet::validation::Issues & issues,
+  const std::string & validator_name)
+{
+  // Avoid duplicate processing of the same pair
+  std::pair<lanelet::Id, lanelet::Id> current_pair = {current_lane.id(), adjacent_lane.id()};
+  std::pair<lanelet::Id, lanelet::Id> reverse_pair = {adjacent_lane.id(), current_lane.id()};
+  if (processed_pairs.count(current_pair) || processed_pairs.count(reverse_pair)) {
+    return;
+  }
+  processed_pairs.insert(current_pair);
+
+  const std::string current_subtype = current_lane.attributeOr(lanelet::AttributeName::Subtype, "");
+  const std::string adjacent_subtype = adjacent_lane.attributeOr(lanelet::AttributeName::Subtype, "");
+  
+  std::string norm_current = current_subtype.empty() ? "road" : current_subtype;
+  std::string norm_adjacent = adjacent_subtype.empty() ? "road" : adjacent_subtype;
+  
+  std::set<std::string> vehicle_suitable = {"road", "road_shoulder", "pedestrian_lane"};
+  
+  bool current_vehicle = vehicle_suitable.count(norm_current) > 0;
+  bool adjacent_vehicle = vehicle_suitable.count(norm_adjacent) > 0;
+  
+  if (!current_vehicle || !adjacent_vehicle) {
+    std::map<std::string, std::string> substitution_map;
+    substitution_map["adjacent_lanelet_id"] = std::to_string(adjacent_lane.id());
+    issues.emplace_back(construct_issue_from_code(issue_code(validator_name, 1), current_lane.id(), substitution_map));
+  }
+}
+}
+
+lanelet::validation::Issues LateralSubtypeConnectionValidator::operator()(const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::autoware::validation::appendIssues(issues, check_lateral_subtype_connection(map));
+
+  return issues;
+}
+
+lanelet::validation::Issues LateralSubtypeConnectionValidator::check_lateral_subtype_connection(const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules =
+    lanelet::traffic_rules::TrafficRulesFactory::create(
+      "validator", lanelet::Participants::Vehicle);
+  lanelet::routing::RoutingGraphUPtr routing_graph_ptr =
+    lanelet::routing::RoutingGraph::build(map, *traffic_rules);
+
+  std::set<std::pair<lanelet::Id, lanelet::Id>> processed_pairs;
+
+  for (const lanelet::ConstLanelet & lane : map.laneletLayer) {
+    // Check left adjacent lanelet
+    const auto left_adjacent = routing_graph_ptr->adjacentLeft(lane);
+    if (left_adjacent) {
+      check_adjacent_subtype_compatibility(lane, left_adjacent.get(), processed_pairs, issues, this->name());
+    }
+    
+    // Check right adjacent lanelet
+    const auto right_adjacent = routing_graph_ptr->adjacentRight(lane);
+    if (right_adjacent) {
+      check_adjacent_subtype_compatibility(lane, right_adjacent.get(), processed_pairs, issues, this->name());
+    }
+  }
+
+  return issues;
+}
+}  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/test/data/map/intersection/border_sharing_with_wrong_subtype.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/intersection/border_sharing_with_wrong_subtype.osm
@@ -1,0 +1,591 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2" validation_version="1"/>
+  <node id="1082" lat="35.90321499914" lon="139.93274072208">
+    <tag k="local_x" v="3691.3078"/>
+    <tag k="local_y" v="73739.7093"/>
+    <tag k="ele" v="19.163"/>
+  </node>
+  <node id="1083" lat="35.90317547194" lon="139.93276677737">
+    <tag k="type" v="begin"/>
+    <tag k="local_x" v="3693.6112"/>
+    <tag k="local_y" v="73735.2993"/>
+    <tag k="ele" v="19.189"/>
+  </node>
+  <node id="1084" lat="35.90313502738" lon="139.93279338903">
+    <tag k="type" v="end"/>
+    <tag k="local_x" v="3695.9637"/>
+    <tag k="local_y" v="73730.787"/>
+    <tag k="ele" v="19.222"/>
+  </node>
+  <node id="1085" lat="35.90309583267" lon="139.93281922261">
+    <tag k="local_x" v="3698.2475"/>
+    <tag k="local_y" v="73726.4141"/>
+    <tag k="ele" v="19.25"/>
+  </node>
+  <node id="1171" lat="35.90332877701" lon="139.93266608346">
+    <tag k="local_x" v="3684.7101"/>
+    <tag k="local_y" v="73752.403"/>
+    <tag k="ele" v="19.183"/>
+  </node>
+  <node id="1574" lat="35.90324724957" lon="139.93268258342">
+    <tag k="local_x" v="3686.1003"/>
+    <tag k="local_y" v="73743.3438"/>
+    <tag k="ele" v="19.093"/>
+  </node>
+  <node id="1575" lat="35.90319474982" lon="139.93271705517">
+    <tag k="local_x" v="3689.1475"/>
+    <tag k="local_y" v="73737.4866"/>
+    <tag k="ele" v="19.116"/>
+  </node>
+  <node id="1576" lat="35.90314227735" lon="139.93275155532">
+    <tag k="local_x" v="3692.1973"/>
+    <tag k="local_y" v="73731.6324"/>
+    <tag k="ele" v="19.138"/>
+  </node>
+  <node id="1577" lat="35.90313708319" lon="139.9327549727">
+    <tag k="local_x" v="3692.4994"/>
+    <tag k="local_y" v="73731.0529"/>
+    <tag k="ele" v="19.14"/>
+  </node>
+  <node id="1614" lat="35.90321980489" lon="139.93277505596">
+    <tag k="local_x" v="3694.412"/>
+    <tag k="local_y" v="73740.2085"/>
+    <tag k="ele" v="19.107"/>
+  </node>
+  <node id="1615" lat="35.90316702769" lon="139.93280986158">
+    <tag k="local_x" v="3697.489"/>
+    <tag k="local_y" v="73734.3202"/>
+    <tag k="ele" v="19.132"/>
+  </node>
+  <node id="1616" lat="35.90316180557" lon="139.93281327823">
+    <tag k="local_x" v="3697.791"/>
+    <tag k="local_y" v="73733.7376"/>
+    <tag k="ele" v="19.139"/>
+  </node>
+  <node id="1777" lat="35.90324763881" lon="139.93254969404">
+    <tag k="local_x" v="3674.1085"/>
+    <tag k="local_y" v="73743.518"/>
+    <tag k="ele" v="19.1"/>
+  </node>
+  <node id="1778" lat="35.90327038869" lon="139.93260161114">
+    <tag k="local_x" v="3678.8212"/>
+    <tag k="local_y" v="73745.9902"/>
+    <tag k="ele" v="19.11"/>
+  </node>
+  <node id="1814" lat="35.9033533609" lon="139.93265494467">
+    <tag k="local_x" v="3683.7347"/>
+    <tag k="local_y" v="73755.1408"/>
+    <tag k="ele" v="19.156"/>
+  </node>
+  <node id="1815" lat="35.90335019394" lon="139.93264766691">
+    <tag k="local_x" v="3683.0741"/>
+    <tag k="local_y" v="73754.7967"/>
+    <tag k="ele" v="19.159"/>
+  </node>
+  <node id="1816" lat="35.90334813812" lon="139.93264297168">
+    <tag k="local_x" v="3682.6479"/>
+    <tag k="local_y" v="73754.5733"/>
+    <tag k="ele" v="19.152"/>
+  </node>
+  <node id="1950" lat="35.90332561046" lon="139.9326587503">
+    <tag k="local_x" v="3684.0445"/>
+    <tag k="local_y" v="73752.059"/>
+    <tag k="ele" v="19.183"/>
+  </node>
+  <node id="1952" lat="35.90333205487" lon="139.93267366668">
+    <tag k="local_x" v="3685.3984"/>
+    <tag k="local_y" v="73752.7591"/>
+    <tag k="ele" v="19.183"/>
+  </node>
+  <node id="2033" lat="35.90337588852" lon="139.93270661108">
+    <tag k="local_x" v="3688.4245"/>
+    <tag k="local_y" v="73757.5886"/>
+    <tag k="ele" v="19.131"/>
+  </node>
+  <node id="2034" lat="35.90338663888" lon="139.93273127769">
+    <tag k="local_x" v="3690.6635"/>
+    <tag k="local_y" v="73758.7567"/>
+    <tag k="ele" v="19.129"/>
+  </node>
+  <node id="2047" lat="35.90308447171" lon="139.93278955556">
+    <tag k="local_x" v="3695.5565"/>
+    <tag k="local_y" v="73725.1832"/>
+    <tag k="ele" v="19.187"/>
+  </node>
+  <node id="2048" lat="35.90303402735" lon="139.93282269421">
+    <tag k="local_x" v="3698.4859"/>
+    <tag k="local_y" v="73719.5553"/>
+    <tag k="ele" v="19.219"/>
+  </node>
+  <node id="2052" lat="35.90310933316" lon="139.93284788912">
+    <tag k="local_x" v="3700.8508"/>
+    <tag k="local_y" v="73727.8833"/>
+    <tag k="ele" v="19.177"/>
+  </node>
+  <node id="2053" lat="35.90305999948" lon="139.93288041665">
+    <tag k="local_x" v="3703.7264"/>
+    <tag k="local_y" v="73722.3792"/>
+    <tag k="ele" v="19.221"/>
+  </node>
+  <node id="2168" lat="35.90326327716" lon="139.93270891666">
+    <tag k="local_x" v="3688.4961"/>
+    <tag k="local_y" v="73745.0956"/>
+    <tag k="ele" v="19.134"/>
+  </node>
+  <node id="2169" lat="35.90323913873" lon="139.93272483322">
+    <tag k="local_x" v="3689.9032"/>
+    <tag k="local_y" v="73742.4025"/>
+    <tag k="ele" v="19.148"/>
+  </node>
+  <node id="2172" lat="35.90307138852" lon="139.9328353338">
+    <tag k="local_x" v="3699.6718"/>
+    <tag k="local_y" v="73723.6869"/>
+    <tag k="ele" v="19.267"/>
+  </node>
+  <node id="2173" lat="35.90304694411" lon="139.93285141618">
+    <tag k="local_x" v="3701.0935"/>
+    <tag k="local_y" v="73720.9597"/>
+    <tag k="ele" v="19.284"/>
+  </node>
+  <node id="2224" lat="35.90327066586" lon="139.93253411149">
+    <tag k="local_x" v="3672.7302"/>
+    <tag k="local_y" v="73746.0875"/>
+    <tag k="ele" v="19.157"/>
+  </node>
+  <node id="2225" lat="35.90329449985" lon="139.93258891622">
+    <tag k="local_x" v="3677.7048"/>
+    <tag k="local_y" v="73748.6771"/>
+    <tag k="ele" v="19.155"/>
+  </node>
+  <node id="2226" lat="35.90336355516" lon="139.93274647201">
+    <tag k="local_x" v="3692.0067"/>
+    <tag k="local_y" v="73756.1813"/>
+    <tag k="ele" v="19.188"/>
+  </node>
+  <node id="2923" lat="35.90329266613" lon="139.93251924971">
+    <tag k="local_x" v="3671.4157"/>
+    <tag k="local_y" v="73748.5424"/>
+    <tag k="ele" v="19.156"/>
+  </node>
+  <node id="2935" lat="35.90334030539" lon="139.93276174945">
+    <tag k="local_x" v="3693.3572"/>
+    <tag k="local_y" v="73753.5874"/>
+    <tag k="ele" v="19.138"/>
+  </node>
+  <node id="3465" lat="35.90327588868" lon="139.93273808383">
+    <tag k="local_x" v="3691.1435"/>
+    <tag k="local_y" v="73746.4657"/>
+    <tag k="ele" v="19.077"/>
+  </node>
+  <node id="3476" lat="35.90325086072" lon="139.93268019456">
+    <tag k="local_x" v="3685.8891"/>
+    <tag k="local_y" v="73743.7467"/>
+    <tag k="ele" v="19.08"/>
+  </node>
+  <node id="7395" lat="35.90330827752" lon="139.9326884171">
+    <tag k="local_x" v="3686.7007"/>
+    <tag k="local_y" v="73750.1072"/>
+    <tag k="ele" v="19.143"/>
+  </node>
+  <node id="7438" lat="35.90337897183" lon="139.93271705589">
+    <tag k="local_x" v="3689.3708"/>
+    <tag k="local_y" v="73757.9203"/>
+    <tag k="ele" v="19.133"/>
+  </node>
+  <node id="7439" lat="35.90337388812" lon="139.93270886085">
+    <tag k="local_x" v="3688.6251"/>
+    <tag k="local_y" v="73757.3645"/>
+    <tag k="ele" v="19.136"/>
+  </node>
+  <node id="7440" lat="35.90336755559" lon="139.93270044433">
+    <tag k="local_x" v="3687.8579"/>
+    <tag k="local_y" v="73756.6704"/>
+    <tag k="ele" v="19.143"/>
+  </node>
+  <node id="7441" lat="35.90336061109" lon="139.93269286159">
+    <tag k="local_x" v="3687.1652"/>
+    <tag k="local_y" v="73755.9076"/>
+    <tag k="ele" v="19.152"/>
+  </node>
+  <node id="7442" lat="35.90335305552" lon="139.9326861115">
+    <tag k="local_x" v="3686.5469"/>
+    <tag k="local_y" v="73755.0762"/>
+    <tag k="ele" v="19.162"/>
+  </node>
+  <node id="7443" lat="35.90334502757" lon="139.93268027753">
+    <tag k="local_x" v="3686.0107"/>
+    <tag k="local_y" v="73754.1915"/>
+    <tag k="ele" v="19.173"/>
+  </node>
+  <node id="7444" lat="35.90333658322" lon="139.93267547195">
+    <tag k="local_x" v="3685.5668"/>
+    <tag k="local_y" v="73753.2596"/>
+    <tag k="ele" v="19.18"/>
+  </node>
+  <node id="7445" lat="35.90332780517" lon="139.93267166706">
+    <tag k="local_x" v="3685.2128"/>
+    <tag k="local_y" v="73752.2897"/>
+    <tag k="ele" v="19.18"/>
+  </node>
+  <node id="7446" lat="35.90331874914" lon="139.93266894411">
+    <tag k="local_x" v="3684.9561"/>
+    <tag k="local_y" v="73751.2879"/>
+    <tag k="ele" v="19.169"/>
+  </node>
+  <node id="7447" lat="35.90330952761" lon="139.93266727832">
+    <tag k="local_x" v="3684.7946"/>
+    <tag k="local_y" v="73750.2667"/>
+    <tag k="ele" v="19.158"/>
+  </node>
+  <node id="7448" lat="35.90330022152" lon="139.93266674949">
+    <tag k="local_x" v="3684.7356"/>
+    <tag k="local_y" v="73749.235"/>
+    <tag k="ele" v="19.143"/>
+  </node>
+  <node id="7449" lat="35.9032909163" lon="139.93266733321">
+    <tag k="local_x" v="3684.777"/>
+    <tag k="local_y" v="73748.2023"/>
+    <tag k="ele" v="19.128"/>
+  </node>
+  <node id="7450" lat="35.90328169373" lon="139.93266899957">
+    <tag k="local_x" v="3684.9162"/>
+    <tag k="local_y" v="73747.1777"/>
+    <tag k="ele" v="19.113"/>
+  </node>
+  <node id="7451" lat="35.90327361068" lon="139.93267147175">
+    <tag k="local_x" v="3685.1295"/>
+    <tag k="local_y" v="73746.2787"/>
+    <tag k="ele" v="19.099"/>
+  </node>
+  <node id="7455" lat="35.90328055515" lon="139.93270258331">
+    <tag k="local_x" v="3687.9455"/>
+    <tag k="local_y" v="73747.0183"/>
+    <tag k="ele" v="19.13"/>
+  </node>
+  <node id="7456" lat="35.90328680486" lon="139.93270066655">
+    <tag k="local_x" v="3687.7801"/>
+    <tag k="local_y" v="73747.7134"/>
+    <tag k="ele" v="19.129"/>
+  </node>
+  <node id="7457" lat="35.90329349979" lon="139.93269944414">
+    <tag k="local_x" v="3687.6779"/>
+    <tag k="local_y" v="73748.4572"/>
+    <tag k="ele" v="19.125"/>
+  </node>
+  <node id="7458" lat="35.90330024968" lon="139.93269902771">
+    <tag k="local_x" v="3687.6485"/>
+    <tag k="local_y" v="73749.2063"/>
+    <tag k="ele" v="19.125"/>
+  </node>
+  <node id="7459" lat="35.90330702745" lon="139.93269941652">
+    <tag k="local_x" v="3687.6918"/>
+    <tag k="local_y" v="73749.9577"/>
+    <tag k="ele" v="19.134"/>
+  </node>
+  <node id="7460" lat="35.90331372223" lon="139.93270061094">
+    <tag k="local_x" v="3687.8077"/>
+    <tag k="local_y" v="73750.6991"/>
+    <tag k="ele" v="19.141"/>
+  </node>
+  <node id="7461" lat="35.90332030517" lon="139.93270261136">
+    <tag k="local_x" v="3687.9962"/>
+    <tag k="local_y" v="73751.4273"/>
+    <tag k="ele" v="19.149"/>
+  </node>
+  <node id="7462" lat="35.90332669372" lon="139.93270536127">
+    <tag k="local_x" v="3688.2521"/>
+    <tag k="local_y" v="73752.1332"/>
+    <tag k="ele" v="19.156"/>
+  </node>
+  <node id="7463" lat="35.90333280495" lon="139.93270886067">
+    <tag k="local_x" v="3688.5753"/>
+    <tag k="local_y" v="73752.8076"/>
+    <tag k="ele" v="19.164"/>
+  </node>
+  <node id="7464" lat="35.90333866656" lon="139.93271308371">
+    <tag k="local_x" v="3688.9635"/>
+    <tag k="local_y" v="73753.4536"/>
+    <tag k="ele" v="19.17"/>
+  </node>
+  <node id="7465" lat="35.90334413855" lon="139.93271800012">
+    <tag k="local_x" v="3689.4138"/>
+    <tag k="local_y" v="73754.0557"/>
+    <tag k="ele" v="19.176"/>
+  </node>
+  <node id="7466" lat="35.90334919404" lon="139.93272352828">
+    <tag k="local_x" v="3689.9188"/>
+    <tag k="local_y" v="73754.611"/>
+    <tag k="ele" v="19.18"/>
+  </node>
+  <node id="7467" lat="35.90335380549" lon="139.93272961092">
+    <tag k="local_x" v="3690.4733"/>
+    <tag k="local_y" v="73755.1165"/>
+    <tag k="ele" v="19.184"/>
+  </node>
+  <node id="7468" lat="35.90335769407" lon="139.93273591713">
+    <tag k="local_x" v="3691.0471"/>
+    <tag k="local_y" v="73755.5416"/>
+    <tag k="ele" v="19.186"/>
+  </node>
+  <node id="7472" lat="35.90328758307" lon="139.93273405611">
+    <tag k="local_x" v="3690.7942"/>
+    <tag k="local_y" v="73747.7668"/>
+    <tag k="ele" v="19.086"/>
+  </node>
+  <node id="7473" lat="35.90329197172" lon="139.93273272173">
+    <tag k="local_x" v="3690.6791"/>
+    <tag k="local_y" v="73748.2549"/>
+    <tag k="ele" v="19.094"/>
+  </node>
+  <node id="7474" lat="35.90329611109" lon="139.93273194476">
+    <tag k="local_x" v="3690.614"/>
+    <tag k="local_y" v="73748.7148"/>
+    <tag k="ele" v="19.099"/>
+  </node>
+  <node id="7475" lat="35.90330030472" lon="139.93273169453">
+    <tag k="local_x" v="3690.5965"/>
+    <tag k="local_y" v="73749.1802"/>
+    <tag k="ele" v="19.104"/>
+  </node>
+  <node id="7476" lat="35.90330449919" lon="139.93273194405">
+    <tag k="local_x" v="3690.6241"/>
+    <tag k="local_y" v="73749.6452"/>
+    <tag k="ele" v="19.109"/>
+  </node>
+  <node id="7477" lat="35.90330863836" lon="139.93273266637">
+    <tag k="local_x" v="3690.6943"/>
+    <tag k="local_y" v="73750.1036"/>
+    <tag k="ele" v="19.114"/>
+  </node>
+  <node id="7478" lat="35.90331269387" lon="139.93273391618">
+    <tag k="local_x" v="3690.812"/>
+    <tag k="local_y" v="73750.5522"/>
+    <tag k="ele" v="19.118"/>
+  </node>
+  <node id="7479" lat="35.90331666588" lon="139.93273561147">
+    <tag k="local_x" v="3690.9698"/>
+    <tag k="local_y" v="73750.9911"/>
+    <tag k="ele" v="19.121"/>
+  </node>
+  <node id="7480" lat="35.90332047169" lon="139.93273777772">
+    <tag k="local_x" v="3691.1699"/>
+    <tag k="local_y" v="73751.4111"/>
+    <tag k="ele" v="19.124"/>
+  </node>
+  <node id="7481" lat="35.9033240554" lon="139.93274041681">
+    <tag k="local_x" v="3691.4124"/>
+    <tag k="local_y" v="73751.806"/>
+    <tag k="ele" v="19.127"/>
+  </node>
+  <node id="7482" lat="35.90332747218" lon="139.93274344487">
+    <tag k="local_x" v="3691.6898"/>
+    <tag k="local_y" v="73752.182"/>
+    <tag k="ele" v="19.128"/>
+  </node>
+  <node id="7483" lat="35.90333058318" lon="139.93274686156">
+    <tag k="local_x" v="3692.0019"/>
+    <tag k="local_y" v="73752.5237"/>
+    <tag k="ele" v="19.13"/>
+  </node>
+  <node id="7484" lat="35.90333344404" lon="139.93275063842">
+    <tag k="local_x" v="3692.3462"/>
+    <tag k="local_y" v="73752.8373"/>
+    <tag k="ele" v="19.132"/>
+  </node>
+  <node id="7485" lat="35.90333616634" lon="139.93275505543">
+    <tag k="local_x" v="3692.7481"/>
+    <tag k="local_y" v="73753.1349"/>
+    <tag k="ele" v="19.134"/>
+  </node>
+  <node id="7935" lat="35.90332636061" lon="139.93259455533">
+    <tag k="local_x" v="3678.2523"/>
+    <tag k="local_y" v="73752.2055"/>
+    <tag k="ele" v="19.163"/>
+  </node>
+  <node id="7939" lat="35.90327119373" lon="139.93253527791">
+    <tag k="local_x" v="3672.8361"/>
+    <tag k="local_y" v="73746.1449"/>
+    <tag k="ele" v="19.157"/>
+  </node>
+  <way id="11">
+    <nd ref="3465"/>
+    <nd ref="1614"/>
+    <nd ref="1615"/>
+    <nd ref="1616"/>
+    <nd ref="2052"/>
+    <nd ref="2053"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="12">
+    <nd ref="2168"/>
+    <nd ref="2169"/>
+    <nd ref="1082"/>
+    <nd ref="1083"/>
+    <nd ref="1084"/>
+    <nd ref="1085"/>
+    <nd ref="2172"/>
+    <nd ref="2173"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="13">
+    <nd ref="2048"/>
+    <nd ref="2047"/>
+    <nd ref="1577"/>
+    <nd ref="1576"/>
+    <nd ref="1575"/>
+    <nd ref="1574"/>
+    <nd ref="3476"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="299">
+    <nd ref="3476"/>
+    <nd ref="7451"/>
+    <nd ref="7450"/>
+    <nd ref="7449"/>
+    <nd ref="7448"/>
+    <nd ref="7447"/>
+    <nd ref="7446"/>
+    <nd ref="7445"/>
+    <nd ref="7444"/>
+    <nd ref="7443"/>
+    <nd ref="7442"/>
+    <nd ref="7441"/>
+    <nd ref="7440"/>
+    <nd ref="7439"/>
+    <nd ref="7438"/>
+    <nd ref="2034"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="300">
+    <nd ref="2168"/>
+    <nd ref="7455"/>
+    <nd ref="7456"/>
+    <nd ref="7457"/>
+    <nd ref="7458"/>
+    <nd ref="7459"/>
+    <nd ref="7460"/>
+    <nd ref="7461"/>
+    <nd ref="7462"/>
+    <nd ref="7463"/>
+    <nd ref="7464"/>
+    <nd ref="7465"/>
+    <nd ref="7466"/>
+    <nd ref="7467"/>
+    <nd ref="7468"/>
+    <nd ref="2226"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="301">
+    <nd ref="2935"/>
+    <nd ref="7485"/>
+    <nd ref="7484"/>
+    <nd ref="7483"/>
+    <nd ref="7482"/>
+    <nd ref="7481"/>
+    <nd ref="7480"/>
+    <nd ref="7479"/>
+    <nd ref="7478"/>
+    <nd ref="7477"/>
+    <nd ref="7476"/>
+    <nd ref="7475"/>
+    <nd ref="7474"/>
+    <nd ref="7473"/>
+    <nd ref="7472"/>
+    <nd ref="3465"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="307">
+    <nd ref="2923"/>
+    <nd ref="7935"/>
+    <nd ref="1816"/>
+    <nd ref="1815"/>
+    <nd ref="1814"/>
+    <nd ref="2033"/>
+    <nd ref="2034"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <tag k="width" v="0.200"/>
+  </way>
+  <way id="309">
+    <nd ref="2935"/>
+    <nd ref="7395"/>
+    <nd ref="1778"/>
+    <nd ref="1777"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <way id="310">
+    <nd ref="2226"/>
+    <nd ref="1952"/>
+    <nd ref="1171"/>
+    <nd ref="1950"/>
+    <nd ref="2225"/>
+    <nd ref="7939"/>
+    <nd ref="2224"/>
+    <tag k="type" v="virtual"/>
+  </way>
+  <relation id="96">
+    <member type="way" role="left" ref="299"/>
+    <member type="way" role="right" ref="300"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+    <tag k="turn_direction" v="right"/>
+  </relation>
+  <relation id="97">
+    <member type="way" role="left" ref="301"/>
+    <member type="way" role="right" ref="300"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="walkway"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+    <tag k="turn_direction" v="left"/>
+  </relation>
+  <relation id="107">
+    <member type="way" role="left" ref="11"/>
+    <member type="way" role="right" ref="12"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+  </relation>
+  <relation id="108">
+    <member type="way" role="left" ref="13"/>
+    <member type="way" role="right" ref="12"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+  </relation>
+  <relation id="152">
+    <member type="way" role="left" ref="307"/>
+    <member type="way" role="right" ref="310"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+    <tag k="turn_direction" v="straight"/>
+  </relation>
+  <relation id="153">
+    <member type="way" role="left" ref="309"/>
+    <member type="way" role="right" ref="310"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="no"/>
+    <tag k="turn_direction" v="straight"/>
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_lateral_subtype_connection.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_lateral_subtype_connection.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "map_validation_tester.hpp"
 #include "lanelet2_map_validator/validators/intersection/lateral_subtype_connection.hpp"
+#include "map_validation_tester.hpp"
 
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
@@ -27,7 +27,8 @@ private:
 
 TEST_F(TestLateralSubtypeConnectionValidator, ValidatorAvailability)  // NOLINT for gtest
 {
-  std::string expected_validator_name = lanelet::autoware::validation::LateralSubtypeConnectionValidator::name();
+  std::string expected_validator_name =
+    lanelet::autoware::validation::LateralSubtypeConnectionValidator::name();
 
   lanelet::validation::Strings validators =
     lanelet::validation::availabeChecks(expected_validator_name);  // cspell:disable-line
@@ -64,6 +65,6 @@ TEST_F(TestLateralSubtypeConnectionValidator, InvalidSubtypeAdjacency)  // NOLIN
   lanelet::autoware::validation::LateralSubtypeConnectionValidator checker;
   const auto & issues = checker(*map_);
 
-  EXPECT_GT(issues.size(), 0);  
+  EXPECT_GT(issues.size(), 0);
   EXPECT_EQ(issues[0].id, 97) << "Issue should be for lanelet 96";
 }

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_lateral_subtype_connection.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_lateral_subtype_connection.cpp
@@ -1,0 +1,69 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "map_validation_tester.hpp"
+#include "lanelet2_map_validator/validators/intersection/lateral_subtype_connection.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <string>
+
+class TestLateralSubtypeConnectionValidator : public MapValidationTester
+{
+private:
+};
+
+TEST_F(TestLateralSubtypeConnectionValidator, ValidatorAvailability)  // NOLINT for gtest
+{
+  std::string expected_validator_name = lanelet::autoware::validation::LateralSubtypeConnectionValidator::name();
+
+  lanelet::validation::Strings validators =
+    lanelet::validation::availabeChecks(expected_validator_name);  // cspell:disable-line
+
+  const uint32_t expected_validator_num = 1;
+  EXPECT_EQ(expected_validator_num, validators.size());
+  EXPECT_EQ(expected_validator_name, validators[0]);
+}
+
+TEST_F(TestLateralSubtypeConnectionValidator, SampleMap)  // NOLINT for gtest
+{
+  load_target_map("sample_map.osm");
+
+  lanelet::autoware::validation::LateralSubtypeConnectionValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}
+
+TEST_F(TestLateralSubtypeConnectionValidator, ValidBorderSharing)  // NOLINT for gtest
+{
+  load_target_map("lane/border_sharing_base.osm");
+
+  lanelet::autoware::validation::LateralSubtypeConnectionValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}
+
+TEST_F(TestLateralSubtypeConnectionValidator, InvalidSubtypeAdjacency)  // NOLINT for gtest
+{
+  load_target_map("lane/border_sharing_with_wrong_subtype.osm");
+
+  lanelet::autoware::validation::LateralSubtypeConnectionValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_GT(issues.size(), 0);  
+  EXPECT_EQ(issues[0].id, 97) << "Issue should be for lanelet 96";
+}


### PR DESCRIPTION
## Description

This PR introduces a new validator: `mapping.lane.lateral_subtype_connection`.  
Its purpose is to ensure that laterally adjacent lanelets (left/right neighbors) have compatible subtypes for vehicle navigation, as required for safe and logical routing in HD maps.

### Validation subjects

Lanelets and their lateral (left/right) adjacency relationships.

### What is validated

This validator checks that:
1. Each lanelet’s left and right adjacent lanelets (as determined by the routing graph) have a compatible subtype.
2. Vehicle-suitable lanelets (`road`, `road_shoulder`, `pedestrian_lane`) are **not** laterally adjacent to non-vehicle-suitable lanelets (e.g., `walkway`, `bicycle_lane`, etc.).

### Added files
#### Main files
* `lateral_subtype_connection.hpp`
* `lateral_subtype_connection.cpp`
* `lateral_subtype_connection.md`

#### Map
* border_sharing_with_wrong_subtype.osm  
  (Contains two adjacent lanelets: one with subtype `road`, one with subtype `walkway`.)

### Modified files

* issues_info.json
  * Added issue code:
    * `Lane.LateralSubtypeConnection-001`

### Output Example

```
Error: [lanelet 97](element://Lanelet/97) [Lane.LateralSubtypeConnection-001] Adjacent [lanelet 96](element://Lanelet/96) has incompatible subtype for linestring sharing. [mapping.lane.lateral_subtype_connection]
```

## **How was this PR tested?

Unit test using the provided test map (border_sharing_with_wrong_subtype.osm), which contains a `road` lanelet laterally adjacent to a `walkway` lanelet.  

## **Notes for reviewers**

- The new test map have 2 error 
```
Error: [lanelet 97](element://Lanelet/97) [Lane.LateralSubtypeConnection-001] Adjacent [lanelet 96](element://Lanelet/96) has incompatible subtype for linestring sharing. [mapping.lane.lateral_subtype_connection]
Error: [lanelet 97](element://Lanelet/97) [Lane.LongitudinalSubtypeConnection-001] A crosswalk or walkway type lanelet cannot have a successor lanelet. [mapping.lane.longitudinal_subtype_connection]
```

## **Effects on system behavior**
