### PR TITLE
feat(docker): add Dockerfile for autoware_lanelet2_map_validator

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,4 @@
 {
-  "words": ["gsub", "githubcli", "pinentry"]
+  "words": ["gsub", "githubcli", "pinentry"],
+  "ignorePaths": ["docker/Dockerfile"]
 }

--- a/autoware_lanelet2_map_validator/package.xml
+++ b/autoware_lanelet2_map_validator/package.xml
@@ -24,6 +24,8 @@
   <depend>pugixml-dev</depend>
   <depend>yaml-cpp</depend>
 
+  <exec_depend>python3-pyside6</exec_depend>
+
   <test_depend>ament_cmake_ros</test_depend>
 
   <export>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+# Start from Autoware core-devel (has ROS2 + Autoware dependencies pre-installed)
+FROM ghcr.io/autowarefoundation/autoware:core-devel
+
+# Install Qt X11 dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxcb-xinerama0=1.14-3ubuntu3 \
+    libxkbcommon-x11-0=1.4.0-1 \
+    libxcb-cursor0=0.1.1-4ubuntu1 \
+    libxrender1=1:0.9.10-1build4 \
+    libxext6=2:1.3.4-1build1 \
+    libxi6=2:1.8-1build1 \
+    libgl1-mesa-glx=23.0.4-0ubuntu1~22.04.1 \
+    libgl1-mesa-dri=23.2.1-1ubuntu3.1~22.04.3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run the same build-and-clean process Autoware uses
+# hadolint ignore=SC1091
+RUN --mount=type=bind,source=./autoware_lanelet2_map_validator,target=/autoware/src/autoware_lanelet2_map_validator \
+    --mount=type=cache,target=/ccache \
+    source /opt/autoware/setup.bash && \
+    rosdep update && \
+    rosdep install -y --from-paths src --ignore-src --rosdistro "$ROS_DISTRO" && \
+    /autoware/build_and_clean.sh /ccache /opt/autoware "--packages-up-to autoware_lanelet2_map_validator"
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Start from Autoware core-devel (has ROS2 + Autoware dependencies pre-installed)
+# Start from Autoware core-devel
 FROM ghcr.io/autowarefoundation/autoware:core-devel
 
 # Install Qt X11 dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1-mesa-dri=23.2.1-1ubuntu3.1~22.04.3 \
     && rm -rf /var/lib/apt/lists/*
 
+COPY autoware_lanelet2_map_validator/map_requirements /home/autoware_lanelet2_map_validator/map_requirements
+COPY autoware_lanelet2_map_validator/config/params.yaml /home/autoware_lanelet2_map_validator/config
+
 # Run the same build-and-clean process Autoware uses
 # hadolint ignore=SC1091
 RUN --mount=type=bind,source=./autoware_lanelet2_map_validator,target=/autoware/src/autoware_lanelet2_map_validator \
@@ -21,6 +24,8 @@ RUN --mount=type=bind,source=./autoware_lanelet2_map_validator,target=/autoware/
     rosdep update && \
     rosdep install -y --from-paths src --ignore-src --rosdistro "$ROS_DISTRO" && \
     /autoware/build_and_clean.sh /ccache /opt/autoware "--packages-up-to autoware_lanelet2_map_validator"
+
+WORKDIR /home/autoware_lanelet2_map_validator
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,69 @@
+# How to use autoware_lanelet2_map_validator with Docker
+
+You can use autoware_lanelet2_map_validator in a docker image.
+
+## How to build
+
+Follow these instructions to build a docker image with autoware_lanelet2_map_validator in it.
+
+**(Assumption) Please install docker to your machine first. Installation methods will vary depending to your operation system.**
+
+1. Go to the base directory of this repository.
+
+   ```bash
+   cd <DIRECTORY_TO_THIS_REPOSITORY>
+   ```
+
+2. Build the docker image
+
+   ```bash
+   docker build -t <IMAGE_NAME> -f docker/Dockerfile .
+   ```
+
+## How to use
+
+### Use Case A: Use the GUI once
+
+1. Configure display settings **(This may vary depending to your operation system!! This example demonstrates in the Ubuntu way**). Grant permission of X11 display to the local user
+
+   ```bash
+   xhost +local:root
+   ```
+
+2. Prepare a folder to pass to the map file (`.osm file`) (and map requirements `.json file` if needed) to the docker container.
+
+   ```bash
+   mkdir <FOLDER_NAME>
+   mv <MAP_FILE> <FOLDERNAME>
+   ```
+
+3. Run a temporary docker container
+
+   ```bash
+   docker run -it --rm -e DISPLAY=$DISPLAY \
+   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+   -v <FOLDER_NAME>:/home/autoware_lanelet2_map_validator \
+   <IMAGE_NAME> \
+   ros2 run autoware_lanelet2_map_validator gui.py
+   ```
+
+   By this command, your files are shared to the docker container in the `/home/autoware_lanelet2_map_validator` directory.
+
+4. Validate your map through the GUI. Note that the map requirements are already in the image, but you can bring your own files with your map by including them in the folder you've prepared before. You should not forget to set the `output_directory` to `/home/autoware_lanelet2_map_validator` to bring the results to your local machine.
+
+5. Closing the GUI will automatically exit the docker container.
+
+### Use Case B: Use it as a CLI
+
+1. Prepare a folder to pass to the map file (`.osm file`) (and map requirements `.json file` if needed) to the docker container.
+
+   ```bash
+   mkdir <FOLDER_NAME>
+   mv <MAP_FILE> <FOLDERNAME>
+   ```
+
+2. You can simply enter to the container by the following command. But do not forget to mount the folder to your map or you cannot pass the map file to the container.
+
+   ```bash
+   docker run -it --rm -v <FOLDER_NAME>:/home/autoware_lanelet2_map_validator <IMAGE_NAME>
+   ```


### PR DESCRIPTION
## Description

add Dockerfile for autoware_lanelet2_map_validator
add document how to use it

## How was this PR tested?

Build
```bash
cd <BASE_DIRECOTRY_OF_THIS_REPOSITORY>
docker build -t autoware_lanelet2_map_validator -f docker/Dockerfile .
```

Run GUI

```bash
xhost +local:root # For display settings
docker run -it --rm -e DISPLAY=$DISPLAY \
-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-v my_mount_directory:/autoware/my_mount_directory \
autoware_lanelet2_map_validator_test:latest \
ros2 run autoware_lanelet2_map_validator gui.py
```


## Notes for reviewers

None.

## Effects on system behavior

None.
