### PR TITLE
chore: remove unnecessary prerequisites from map requirements

### DIFF
--- a/autoware_lanelet2_map_validator/map_requirements/autoware_requirement_set.json
+++ b/autoware_lanelet2_map_validator/map_requirements/autoware_requirement_set.json
@@ -67,12 +67,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -82,9 +77,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }
@@ -99,20 +91,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -120,15 +102,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -147,12 +121,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_2_0.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2024_7_0.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/cargo_transport-v2025_3_0.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/common.json
@@ -67,12 +67,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -82,9 +77,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }
@@ -99,20 +91,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -120,15 +102,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -147,12 +121,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/delivery_robot-v2023_10_2.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/delivery_robot-v2023_10_2.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_44_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_45_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_46_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_47_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/robo_taxi-v0_48_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v2_3_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v3_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v3_1_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v4_0_1.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/shuttle_bus-v4_1_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
@@ -67,12 +67,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -82,9 +77,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }
@@ -99,20 +91,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -120,15 +102,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -147,12 +121,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/delivery_robot-v2023_10_2.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/delivery_robot-v2023_10_2.json
@@ -24,12 +24,7 @@
           "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
         },
         {
-          "name": "mapping.intersection.virtual_traffic_light_line_order",
-          "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            }
-          ]
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
         }
       ]
     },
@@ -39,9 +34,6 @@
         {
           "name": "mapping.intersection.virtual_traffic_light_section_overlap",
           "prerequisites": [
-            {
-              "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
-            },
             {
               "name": "mapping.intersection.virtual_traffic_light_line_order"
             }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_44_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_45_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_46_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_47_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v2_3_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_0_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_1_0.json
@@ -59,20 +59,10 @@
           "name": "mapping.traffic_light.missing_regulatory_elements"
         },
         {
-          "name": "mapping.traffic_light.missing_referrers",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.missing_referrers"
         },
         {
-          "name": "mapping.traffic_light.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.traffic_light.regulatory_element_details"
         }
       ]
     },
@@ -80,15 +70,7 @@
       "id": "vm-04-02",
       "validators": [
         {
-          "name": "mapping.traffic_light.correct_facing",
-          "prerequisites": [
-            {
-              "name": "mapping.traffic_light.missing_referrers"
-            },
-            {
-              "name": "mapping.traffic_light.regulatory_element_details"
-            }
-          ]
+          "name": "mapping.traffic_light.correct_facing"
         }
       ]
     },
@@ -107,12 +89,7 @@
           "name": "mapping.crosswalk.missing_regulatory_elements"
         },
         {
-          "name": "mapping.crosswalk.regulatory_element_details",
-          "prerequisites": [
-            {
-              "name": "mapping.crosswalk.missing_regulatory_elements"
-            }
-          ]
+          "name": "mapping.crosswalk.regulatory_element_details"
         }
       ]
     }

--- a/autoware_lanelet2_map_validator/src/validators/intersection/virtual_traffic_light_line_order.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/virtual_traffic_light_line_order.cpp
@@ -66,6 +66,14 @@ VirtualTrafficLightLineOrderValidator::check_virtual_traffic_light_line_order(
       continue;
     }
 
+    // omit invalid reg_elem
+    if (
+      reg_elem->getParameters<lanelet::ConstLineString3d>("start_line").empty() ||
+      reg_elem->getParameters<lanelet::ConstLineString3d>(lanelet::RoleName::RefLine).empty() ||
+      reg_elem->getParameters<lanelet::ConstLineString3d>("end_line").empty()) {
+      continue;
+    }
+
     // retrieve start_line and stop_line with their corresponding lanelet.
     const lanelet::ConstLineString3d start_line =
       reg_elem->getParameters<lanelet::ConstLineString3d>("start_line").front();


### PR DESCRIPTION
## Description

This PR removes unnecessary `prerequisites` from map requirements.

We can classify two types of prerequisites

- A constraint to a complicated validator so that it will not crash when the prerequisite is not met.
- A guarantee that the latter validator also has a comprehensiveness of primitives to be checked. (e. g. If a traffic light regulatory element is missing, we cannot say that all traffic lights are perfect even if the latter validators succeeded)

However, the second role `prerequisites` hold was quite unuseful so I decided to delete this.

I've checked that prerequisites removed here doesn't crashes the latter validation that validators have enough exception handling. (but I added one to virtual_traffic_light_line_order.cpp)

## How was this PR tested?

Tested that `autoware_lanelet2_map_validator` doesn't crashes against some maps.

## Notes for reviewers

None.

## Effects on system behavior

None.
