### PR TITLE
fix: ignore crosswalks for some validators

### DIFF
--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
@@ -62,6 +62,11 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
 
     // Check precise coverage for nearby lanelets
     for (const lanelet::ConstLanelet & lanelet : nearby_lanelets) {
+      if (
+        lanelet.attributeOr(lanelet::AttributeName::Subtype, "") !=
+        std::string(lanelet::AttributeValueString::Road)) {
+        continue;
+      }
       lanelet::BasicPolygon2d lanelet_polygon = lanelet.polygon2d().basicPolygon();
       if (boost::geometry::covered_by(lanelet_polygon, area_polygon2d)) {
         lanelet::Id tagged_area_id = lanelet.attributeOr("intersection_area", lanelet::InvalId);


### PR DESCRIPTION
## Description

I found that `regulatory_element_details_for_traffic_lights` and `intersection_area_tagging` doesn't have error handling when crosswalk lanelets involve. This PR fixes it.

## How was this PR tested?

Tested that real map validation will not output false negative errors.
Tested that `colcon test` passes.

## Notes for reviewers

**I'll bypass merge all the necessary changes to `feat/v1.5.0/the_grand_finale` first and then request for reviews.**

## Effects on system behavior

None.
