### PR TITLE
feat(lane): added validator for road shoulder (vm-01-15)

### DIFF
--- a/autoware_lanelet2_map_validator/config/issues_info.json
+++ b/autoware_lanelet2_map_validator/config/issues_info.json
@@ -723,16 +723,16 @@
     "severity": "Error",
     "primitive": "lanelet",
     "message": {
-      "en": "Road shoulder with only left/right adjacent lanelet must be adjacent to a road subtype lanelet.",
-      "ja": "左/右にのみ隣接するレーンを持つ路肩レーンは、road サブタイプのレーンに隣接していなければなりません。"
+      "en": "Adjacent lanelet must be a road subtype lanelet.",
+      "ja": "隣接するレーンレットは道路サブタイプのレーンレットでなければなりません。"
     }
   },
   "Lane.RoadShoulder-003": {
     "severity": "Error",
     "primitive": "linestring",
     "message": {
-      "en": "Road shoulder with empty left/right side must have a left/right bound with road_border type.",
-      "ja": "左/右側が空の路肩レーンの左/右境界は、road_border タイプでなければなりません。"
+      "en": "The bound linestring on the empty side must have road_border type.",
+      "ja": "空いている側の境界線ストリングは road_border タイプでなければなりません。"
     }
   }
 }

--- a/autoware_lanelet2_map_validator/config/issues_info.json
+++ b/autoware_lanelet2_map_validator/config/issues_info.json
@@ -710,5 +710,29 @@
       "en": "Buffer zone polygon must not overlap with {lanelet_subtype} lanelet (ID: {lanelet_id}).",
       "ja": "導流帯ポリゴンは {lanelet_subtype} lanelet (ID: {lanelet_id}) と重複してはいけません。"
     }
+  },
+  "Lane.RoadShoulder-001": {
+    "severity": "Error",
+    "primitive": "lanelet",
+    "message": {
+      "en": "Road shoulder lanelet has no adjacent lanelets.",
+      "ja": "路肩レーンには隣接するレーンが存在しません。"
+    }
+  },
+  "Lane.RoadShoulder-002": {
+    "severity": "Error",
+    "primitive": "lanelet",
+    "message": {
+      "en": "Road shoulder with only left/right adjacent lanelet must be adjacent to a road subtype lanelet.",
+      "ja": "左/右にのみ隣接するレーンを持つ路肩レーンは、road サブタイプのレーンに隣接していなければなりません。"
+    }
+  },
+  "Lane.RoadShoulder-003": {
+    "severity": "Error",
+    "primitive": "linestring",
+    "message": {
+      "en": "Road shoulder with empty left/right side must have a left/right bound with road_border type.",
+      "ja": "左/右側が空の路肩レーンの左/右境界は、road_border タイプでなければなりません。"
+    }
   }
 }

--- a/autoware_lanelet2_map_validator/docs/lane/road_shoulder.md
+++ b/autoware_lanelet2_map_validator/docs/lane/road_shoulder.md
@@ -1,0 +1,30 @@
+# road_shoulder
+
+## Validator name
+
+mapping.lane.road_shoulder
+
+## Feature
+
+This validator implements the VM-01-15 requirement for road shoulder lanelets. It ensures that road shoulder lanelets have proper adjacent lanelets and border configurations.
+
+The validator specifically checks:
+
+- That road shoulder lanelets have at least one adjacent lanelet
+- That adjacent lanelets have the proper 'road' subtype when a road shoulder has only one adjacent lanelet
+- That the outer boundary of a road shoulder (the side without an adjacent lanelet) is properly marked as a 'road_border'
+
+| Issue Code            | Message                                                                                         | Severity | Primitive  | Description                                                                            | Approach                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Lane.RoadShoulder-001 | Road shoulder lanelet has no adjacent lanelets.                                                 | Error    | Lanelet    | Road shoulder lanelets must have at least one adjacent lanelet.                        | Check if a road shoulder has at least one adjacent lanelet on either side. |
+| Lane.RoadShoulder-002 | Road shoulder with only left/right adjacent lanelet must be adjacent to a road subtype lanelet. | Error    | Lanelet    | If a road shoulder has only one adjacent lanelet, it must be a road subtype.           | Check that the single adjacent lanelet has a 'road' subtype.               |
+| Lane.RoadShoulder-003 | Road shoulder with empty left/right side must have a left/right bound with road_border type.    | Error    | LineString | If a road shoulder has an empty side, the boundary on that side must be a road_border. | Check that the boundary on the empty side has a 'road_border' type.        |
+
+## Parameters
+
+None.
+
+## Related source codes
+
+- road_shoulder.cpp
+- road_shoulder.hpp

--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/road_shoulder.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/road_shoulder.hpp
@@ -1,0 +1,36 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__ROAD_SHOULDER_HPP_
+#define LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__ROAD_SHOULDER_HPP_
+
+#include <lanelet2_validation/Validation.h>
+#include <lanelet2_validation/ValidatorFactory.h>
+
+namespace lanelet::autoware::validation
+{
+class RoadShoulderValidator : public lanelet::validation::MapValidator
+{
+public:
+  // Write the validator's name here
+  constexpr static const char * name() { return "mapping.lane.road_shoulder"; }
+
+  lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
+
+private:
+  lanelet::validation::Issues check_road_shoulder(const lanelet::LaneletMap & map);
+};
+}  // namespace lanelet::autoware::validation
+
+#endif  // LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__ROAD_SHOULDER_HPP_

--- a/autoware_lanelet2_map_validator/src/validators/lane/road_shoulder.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/lane/road_shoulder.cpp
@@ -1,0 +1,102 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/lane/road_shoulder.hpp"
+
+#include "lanelet2_map_validator/utils.hpp"
+
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+
+#include <string>
+#include <vector>
+
+namespace lanelet::autoware::validation
+{
+namespace
+{
+lanelet::validation::RegisterMapValidator<RoadShoulderValidator> reg;
+}
+
+lanelet::validation::Issues RoadShoulderValidator::operator()(const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::autoware::validation::appendIssues(issues, check_road_shoulder(map));
+
+  return issues;
+}
+
+lanelet::validation::Issues RoadShoulderValidator::check_road_shoulder(
+  const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules =
+    lanelet::traffic_rules::TrafficRulesFactory::create(
+      "validator", lanelet::Participants::Vehicle);
+
+  lanelet::routing::RoutingGraphUPtr routing_graph_ptr =
+    lanelet::routing::RoutingGraph::build(map, *traffic_rules);
+
+  for (const auto & lanelet : map.laneletLayer) {
+    const auto & attrs = lanelet.attributes();
+    const auto & type_it = attrs.find(lanelet::AttributeName::Type);
+    const auto & subtype_it = attrs.find(lanelet::AttributeName::Subtype);
+
+    if (
+      type_it == attrs.end() || subtype_it == attrs.end() || type_it->second != "lanelet" ||
+      subtype_it->second != "road_shoulder") {
+      continue;
+    }
+
+    const auto left_lanelets = routing_graph_ptr->adjacentLeft(lanelet);
+    const auto right_lanelets = routing_graph_ptr->adjacentRight(lanelet);
+    const bool has_left = left_lanelets.has_value();
+    const bool has_right = right_lanelets.has_value();
+
+    // Issue-001: Road shoulder must have at least one adjacent lanelet
+    if (!has_left && !has_right) {
+      issues.push_back(construct_issue_from_code(issue_code(this->name(), 1), lanelet.id()));
+      continue;
+    }
+
+    if (has_left != has_right) {
+      // Issue-002: Check if adjacent lanelet is a road
+      const auto & adjacent_lanelets = has_left ? left_lanelets : right_lanelets;
+      const auto & adjacent = adjacent_lanelets.value();
+      const auto & adj_attrs = adjacent.attributes();
+      const auto & adj_subtype_it = adj_attrs.find(lanelet::AttributeName::Subtype);
+
+      if (adj_subtype_it == adj_attrs.end() || adj_subtype_it->second != "road") {
+        issues.push_back(construct_issue_from_code(issue_code(this->name(), 2), lanelet.id()));
+      }
+
+      // Issue-003: Check if empty side bound is road_border
+      const auto & empty_side_bound = has_left ? lanelet.rightBound() : lanelet.leftBound();
+      const auto & bound_attrs = empty_side_bound.attributes();
+      const auto & bound_type_it = bound_attrs.find(lanelet::AttributeName::Type);
+
+      if (bound_type_it == bound_attrs.end() || bound_type_it->second != "road_border") {
+        issues.push_back(
+          construct_issue_from_code(issue_code(this->name(), 3), empty_side_bound.id()));
+      }
+    }
+  }
+
+  return issues;
+}
+}  // namespace lanelet::autoware::validation

--- a/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_empty_side_no_road_border.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_empty_side_no_road_border.osm
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm generator="VMB">
   <MetaInfo format_version="1" map_version="2"/>
-  <!-- First lanelet: road_shoulder -->
   <node id="1" lat="35.90312398544" lon="139.93324675646">
     <tag k="local_x" v="3736.8634"/>
     <tag k="local_y" v="73729.1154"/>
@@ -52,8 +51,6 @@
     <tag k="local_y" v="73732.2284"/>
     <tag k="ele" v="19.3259"/>
   </node>
-
-  <!-- Second lanelet: road -->
   <node id="11" lat="35.90307622762" lon="139.93327796832">
     <tag k="local_x" v="3739.6075"/>
     <tag k="local_y" v="73723.7673"/>
@@ -94,8 +91,6 @@
     <tag k="local_y" v="73725.4594"/>
     <tag k="ele" v="19.3259"/>
   </node>
-
-  <!-- Ways for road_shoulder lanelet -->
   <way id="19">
     <nd ref="1"/>
     <nd ref="2"/>
@@ -104,7 +99,6 @@
     <nd ref="5"/>
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
-    <!-- Missing road_border type -->
   </way>
   <way id="20">
     <nd ref="6"/>
@@ -115,8 +109,6 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-
-  <!-- Ways for road lanelet (shared right boundary) -->
   <way id="21">
     <nd ref="11"/>
     <nd ref="12"/>
@@ -125,8 +117,6 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-
-  <!-- Road shoulder lanelet -->
   <relation id="23">
     <member type="way" role="left" ref="19"/>
     <member type="way" role="right" ref="20"/>
@@ -136,8 +126,6 @@
     <tag k="location" v="urban"/>
     <tag k="one_way" v="yes"/>
   </relation>
-
-  <!-- Road lanelet -->
   <relation id="24">
     <member type="way" role="left" ref="20"/>
     <member type="way" role="right" ref="21"/>

--- a/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_empty_side_no_road_border.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_empty_side_no_road_border.osm
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <!-- First lanelet: road_shoulder -->
+  <node id="1" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="2" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="3" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="4" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="5" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="6" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="7" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="8" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="9" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="10" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+
+  <!-- Second lanelet: road -->
+  <node id="11" lat="35.90307622762" lon="139.93327796832">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73723.7673"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="12" lat="35.90308910305" lon="139.9333077326">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73725.1661"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="13" lat="35.90310292378" lon="139.93333968161">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73726.6676"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="14" lat="35.90311632292" lon="139.93337065448">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73728.1233"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="15" lat="35.90305234871" lon="139.93329358177">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73721.1032"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="16" lat="35.90306522504" lon="139.93332334603">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73722.5021"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="17" lat="35.90307904576" lon="139.93335529503">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73724.0036"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="18" lat="35.9030924458" lon="139.93338626789">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73725.4594"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+
+  <!-- Ways for road_shoulder lanelet -->
+  <way id="19">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="4"/>
+    <nd ref="5"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+    <!-- Missing road_border type -->
+  </way>
+  <way id="20">
+    <nd ref="6"/>
+    <nd ref="7"/>
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="10"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+
+  <!-- Ways for road lanelet (shared right boundary) -->
+  <way id="21">
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+
+  <!-- Road shoulder lanelet -->
+  <relation id="23">
+    <member type="way" role="left" ref="19"/>
+    <member type="way" role="right" ref="20"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="lane_change" v="no"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+
+  <!-- Road lanelet -->
+  <relation id="24">
+    <member type="way" role="left" ref="20"/>
+    <member type="way" role="right" ref="21"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="lane_change" v="no"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_with_non_road_adjacent.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_with_non_road_adjacent.osm
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <!-- First lanelet: road_shoulder -->
+  <node id="1" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="2" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="3" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="4" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="5" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="6" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="7" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="8" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="9" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="10" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+
+  <!-- Second lanelet: offroad -->
+  <node id="11" lat="35.90305234871" lon="139.93329358177">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73721.1032"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="12" lat="35.90306522504" lon="139.93332334603">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73722.5021"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="13" lat="35.90307904576" lon="139.93335529503">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73724.0036"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="14" lat="35.9030924458" lon="139.93338626789">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73725.4594"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+
+  <!-- Left boundary of road_shoulder -->
+  <way id="19">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="4"/>
+    <nd ref="5"/>
+    <tag k="type" v="road_border"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+
+  <!-- Shared boundary between road_shoulder and offroad -->
+  <way id="20">
+    <nd ref="6"/>
+    <nd ref="7"/>
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="10"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+
+  <!-- Right boundary of offroad -->
+  <way id="21">
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+
+  <!-- Road shoulder lanelet -->
+  <relation id="23">
+    <member type="way" role="left" ref="19"/>
+    <member type="way" role="right" ref="20"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="lane_change" v="no"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+
+  <!-- Non-road lanelet (adjacent to road shoulder) -->
+  <relation id="24">
+    <member type="way" role="left" ref="20"/>
+    <member type="way" role="right" ref="21"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="pedestrian_lane"/>
+    <tag k="lane_change" v="no"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_with_non_road_adjacent.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_with_non_road_adjacent.osm
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm generator="VMB">
   <MetaInfo format_version="1" map_version="2"/>
-  <!-- First lanelet: road_shoulder -->
   <node id="1" lat="35.90312398544" lon="139.93324675646">
     <tag k="local_x" v="3736.8634"/>
     <tag k="local_y" v="73729.1154"/>
@@ -52,8 +51,6 @@
     <tag k="local_y" v="73732.2284"/>
     <tag k="ele" v="19.3259"/>
   </node>
-
-  <!-- Second lanelet: offroad -->
   <node id="11" lat="35.90305234871" lon="139.93329358177">
     <tag k="local_x" v="3740.9869"/>
     <tag k="local_y" v="73721.1032"/>
@@ -74,8 +71,6 @@
     <tag k="local_y" v="73725.4594"/>
     <tag k="ele" v="19.3259"/>
   </node>
-
-  <!-- Left boundary of road_shoulder -->
   <way id="19">
     <nd ref="1"/>
     <nd ref="2"/>
@@ -85,8 +80,6 @@
     <tag k="type" v="road_border"/>
     <tag k="subtype" v="solid"/>
   </way>
-
-  <!-- Shared boundary between road_shoulder and offroad -->
   <way id="20">
     <nd ref="6"/>
     <nd ref="7"/>
@@ -96,8 +89,6 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-
-  <!-- Right boundary of offroad -->
   <way id="21">
     <nd ref="11"/>
     <nd ref="12"/>
@@ -106,8 +97,6 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-
-  <!-- Road shoulder lanelet -->
   <relation id="23">
     <member type="way" role="left" ref="19"/>
     <member type="way" role="right" ref="20"/>
@@ -117,8 +106,6 @@
     <tag k="location" v="urban"/>
     <tag k="one_way" v="yes"/>
   </relation>
-
-  <!-- Non-road lanelet (adjacent to road shoulder) -->
   <relation id="24">
     <member type="way" role="left" ref="20"/>
     <member type="way" role="right" ref="21"/>

--- a/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_without_adjacent.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/lane/shoulder_road_without_adjacent.osm
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="lane_change" v="no"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/data/map/sample_map.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/sample_map.osm
@@ -6370,14 +6370,14 @@
     <nd ref="10277"/>
     <nd ref="10284"/>
     <nd ref="10286"/>
-    <tag k="type" v="line_thin"/>
+    <tag k="type" v="road_border"/>
     <tag k="subtype" v="solid"/>
   </way>
   <way id="10289">
     <nd ref="10286"/>
     <nd ref="10288"/>
     <nd ref="10290"/>
-    <tag k="type" v="line_thin"/>
+    <tag k="type" v="road_border"/>
     <tag k="subtype" v="solid"/>
   </way>
   <way id="10293">
@@ -6386,7 +6386,7 @@
     <nd ref="10294"/>
     <nd ref="10295"/>
     <nd ref="10296"/>
-    <tag k="type" v="line_thin"/>
+    <tag k="type" v="road_border"/>
     <tag k="subtype" v="solid"/>
   </way>
   <way id="10298">
@@ -6395,7 +6395,7 @@
     <nd ref="10299"/>
     <nd ref="10300"/>
     <nd ref="10301"/>
-    <tag k="type" v="line_thin"/>
+    <tag k="type" v="road_border"/>
     <tag k="subtype" v="solid"/>
   </way>
   <way id="10312">

--- a/autoware_lanelet2_map_validator/test/src/lane/test_road_shoulder.cpp
+++ b/autoware_lanelet2_map_validator/test/src/lane/test_road_shoulder.cpp
@@ -1,0 +1,93 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/lane/road_shoulder.hpp"
+#include "map_validation_tester.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <string>
+
+class TestRoadShoulderValidator : public MapValidationTester
+{
+protected:
+  const std::string test_target_ =
+    std::string(lanelet::autoware::validation::RoadShoulderValidator::name());
+};
+
+TEST_F(TestRoadShoulderValidator, ValidatorAvailability)  // NOLINT for gtest
+{
+  std::string expected_validator_name =
+    lanelet::autoware::validation::RoadShoulderValidator::name();
+
+  lanelet::validation::Strings validators =
+    lanelet::validation::availabeChecks(expected_validator_name);  // cspell:disable-line
+
+  const uint32_t expected_validator_num = 1;
+  EXPECT_EQ(expected_validator_num, validators.size());
+  EXPECT_EQ(expected_validator_name, validators[0]);
+}
+
+TEST_F(TestRoadShoulderValidator, SampleMap)  // NOLINT for gtest
+{
+  load_target_map("sample_map.osm");
+
+  lanelet::autoware::validation::RoadShoulderValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}
+
+TEST_F(TestRoadShoulderValidator, NoAdjacentLanelets)  // NOLINT for gtest
+{
+  load_target_map("lane/shoulder_road_without_adjacent.osm");
+
+  lanelet::autoware::validation::RoadShoulderValidator checker;
+  const auto & issues = checker(*map_);
+
+  ASSERT_FALSE(issues.empty());
+  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 1), 24);
+
+  const auto difference = compare_an_issue(expected_issue, issues[0]);
+  EXPECT_TRUE(difference.empty()) << difference;
+}
+
+TEST_F(TestRoadShoulderValidator, NonRoadAdjacentLanelet)  // NOLINT for gtest
+{
+  load_target_map("lane/shoulder_road_with_non_road_adjacent.osm");
+
+  lanelet::autoware::validation::RoadShoulderValidator checker;
+  const auto & issues = checker(*map_);
+
+  ASSERT_FALSE(issues.empty());
+  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 2), 23);
+
+  const auto difference = compare_an_issue(expected_issue, issues[0]);
+  EXPECT_TRUE(difference.empty()) << difference;
+}
+
+TEST_F(TestRoadShoulderValidator, NoRoadBorderBound)  // NOLINT for gtest
+{
+  load_target_map("lane/shoulder_road_empty_side_no_road_border.osm");
+
+  lanelet::autoware::validation::RoadShoulderValidator checker;
+  const auto & issues = checker(*map_);
+
+  ASSERT_FALSE(issues.empty());
+  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 3), 19);
+
+  const auto difference = compare_an_issue(expected_issue, issues[0]);
+  EXPECT_TRUE(difference.empty()) << difference;
+}


### PR DESCRIPTION
## Description
This PR introduces a new validator: `mapping.lane.road_shoulder`. Its purpose is to validate that all `road_shoulder` subtype lanelets meet the VM-01-15 adjacency and boundary requirements for proper integration with road infrastructure.

### Validation subjects
All `road_shoulder` subtype lanelets (lanelets with `subtype="road_shoulder"`)

### What is validated
This validator implements the VM-01-15 requirement and checks three conditions for `road_shoulder` type lanelets:
- Whether the lanelet has at least one adjacent lanelet
- If there is only one adjacent lanelet, checks whether it is a `road` subtype lanelet
- If there is an empty side (no adjacent lanelet), checks whether the bound linestring has a `road_border` type

### Added files
**Main files:**
- `road_shoulder.hpp`
- `road_shoulder.cpp` 
- `road_shoulder.md`

**Test files:**
- `test_road_shoulder.cpp` 

**Test maps:**
- `shoulder_road_with_non_road_adjacent.osm`
  - `road_shoulder_without_adjacent.osm`
  - `road_shoulder_empty_side_no_road_border.osm`

**Modified files:**
- `issues_info.json`

### Added issue codes:

- `Lane.RoadShoulder-001`: Road shoulder lanelet has no adjacent lanelets
- `Lane.RoadShoulder-002`: Road shoulder with only left/right adjacent lanelet must be adjacent to a road subtype lanelet  
- `Lane.RoadShoulder-003`: Road shoulder with empty left/right side must have a left/right bound with road_border type

## How was this PR tested?
Unit tests

## Notes for reviewers

None.

## Effects on system behavior

None.
