### PR TITLE
fix: add autoware_lanelet2_extension_python as dependency

### DIFF
--- a/autoware_lanelet2_map_validator/package.xml
+++ b/autoware_lanelet2_map_validator/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_extension_python</depend>
   <depend>fmt</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>


### PR DESCRIPTION
## Description

We need this fix since the gui.py depends to autoware_lanelet2_extension_python and `gui.py` cannot be run without it.

## How was this PR tested?

Created a brand new Autoware workspace and checked that autoware_lanelet2_extension_python will be build together by `colcon build --packages-up-to` and the `gui.py` works without errors.

## Notes for reviewers

**I'll bypass merge this one**.

## Effects on system behavior

None.
