### PR TITLE
fix(intersection): added  validation for lanelet with turn_direction tag also need to have turn_direction tag

### DIFF
--- a/autoware_lanelet2_map_validator/config/issues_info.json
+++ b/autoware_lanelet2_map_validator/config/issues_info.json
@@ -183,6 +183,14 @@
       "ja": "この lanelet は intersection_area タグに {area_id} が設定されていますが、その intersection area に完全にカバーされていません。"
     }
   },
+  "Intersection.IntersectionAreaTagging-004": {
+    "severity": "Error",
+    "primitive": "lanelet",
+    "message": {
+      "en": "This lanelet has turn_direction tag '{turn_direction}' but is missing intersection_area tag.",
+      "ja": "この lanelet は turn_direction タグに '{turn_direction}' が設定されていますが、intersection_area タグがありません。"
+    }
+  },
   "Intersection.RegulatoryElementDetailsForVirtualTrafficLights-001": {
     "severity": "Error",
     "primitive": "linestring",

--- a/autoware_lanelet2_map_validator/docs/intersection/intersection_area_tagging.md
+++ b/autoware_lanelet2_map_validator/docs/intersection/intersection_area_tagging.md
@@ -10,6 +10,7 @@ This validator ensures consistency between `intersection_area` polygons and lane
 
 1. All lanelets completely covered by an `intersection_area` polygon have the correct `intersection_area` tag with the polygon's ID
 2. All lanelets with an `intersection_area` tag are completely covered by the referenced intersection area polygon
+3. All lanelets with a `turn_direction` tag also have an `intersection_area` tag
 
 The validator outputs the following issues with the corresponding ID of the primitive.
 
@@ -18,6 +19,7 @@ The validator outputs the following issues with the corresponding ID of the prim
 | Intersection.IntersectionAreaTagging-001 | "This lanelet is covered by intersection area {area_id} but missing intersection_area tag."                                 | Error    | Lanelet   | The lanelet is completely within an intersection area polygon but doesn't have the intersection_area tag | Add an `intersection_area` tag to the lanelet with the value set to the ID of the covering intersection area polygon        |
 | Intersection.IntersectionAreaTagging-002 | "This lanelet is covered by intersection area {expected_area_id} but has incorrect intersection_area tag {actual_area_id}." | Error    | Lanelet   | The lanelet is covered by one intersection area but tagged with a different intersection area ID         | Update the `intersection_area` tag value to match the ID of the intersection area polygon that actually covers this lanelet |
 | Intersection.IntersectionAreaTagging-003 | "This lanelet has intersection_area tag {area_id} but is not completely covered by that intersection area."                 | Error    | Lanelet   | The lanelet has an intersection_area tag but is not completely within the referenced intersection area   | Either remove the `intersection_area` tag or adjust the intersection area polygon to completely cover the lanelet           |
+| Intersection.IntersectionAreaTagging-004 | "This lanelet has turn_direction tag '{turn_direction}' but is missing intersection_area tag."                              | Error    | Lanelet   | The lanelet has a turn_direction tag but is missing the required intersection_area tag                   | Add an `intersection_area` tag to the lanelet with the appropriate intersection area ID                                     |
 
 ## Parameters
 

--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
@@ -68,6 +68,7 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
       lanelet::BasicPolygon2d lanelet_polygon = lanelet.polygon2d().basicPolygon();
       if (polygon_overlap_ratio(lanelet_polygon, area_polygon2d) >= 0.99) {
         lanelet::Id tagged_area_id = lanelet.attributeOr("intersection_area", lanelet::InvalId);
+        
         if (tagged_area_id == lanelet::InvalId) {
           // Issue-001: Lanelet missing intersection_area tag
           std::map<std::string, std::string> area_id_map;
@@ -91,8 +92,20 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
 
   // Issue-003: Lanelet has intersection_area tag but is not completely covered by the referenced
   // area
+  // Issue-004: Lanelet has turn_direction tag but missing intersection_area tag
   for (const lanelet::ConstLanelet & lanelet : map.laneletLayer) {
     lanelet::Id tagged_area_id = lanelet.attributeOr("intersection_area", lanelet::InvalId);
+    std::string turn_direction = lanelet.attributeOr("turn_direction", "");
+    
+    // Issue-004: Check if lanelet has turn_direction but missing intersection_area tag
+    if (!turn_direction.empty() && tagged_area_id == lanelet::InvalId) {
+      std::map<std::string, std::string> tag_map;
+      tag_map["turn_direction"] = turn_direction;
+      issues.emplace_back(
+        construct_issue_from_code(issue_code(this->name(), 4), lanelet.id(), tag_map));
+    }
+    
+    // Issue-003: Continue with existing intersection_area validation
     if (tagged_area_id == lanelet::InvalId) {
       continue;
     }

--- a/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/intersection/intersection_area_tagging.cpp
@@ -68,7 +68,7 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
       lanelet::BasicPolygon2d lanelet_polygon = lanelet.polygon2d().basicPolygon();
       if (polygon_overlap_ratio(lanelet_polygon, area_polygon2d) >= 0.99) {
         lanelet::Id tagged_area_id = lanelet.attributeOr("intersection_area", lanelet::InvalId);
-        
+
         if (tagged_area_id == lanelet::InvalId) {
           // Issue-001: Lanelet missing intersection_area tag
           std::map<std::string, std::string> area_id_map;
@@ -96,7 +96,7 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
   for (const lanelet::ConstLanelet & lanelet : map.laneletLayer) {
     lanelet::Id tagged_area_id = lanelet.attributeOr("intersection_area", lanelet::InvalId);
     std::string turn_direction = lanelet.attributeOr("turn_direction", "");
-    
+
     // Issue-004: Check if lanelet has turn_direction but missing intersection_area tag
     if (!turn_direction.empty() && tagged_area_id == lanelet::InvalId) {
       std::map<std::string, std::string> tag_map;
@@ -104,7 +104,7 @@ lanelet::validation::Issues IntersectionAreaTaggingValidator::check_intersection
       issues.emplace_back(
         construct_issue_from_code(issue_code(this->name(), 4), lanelet.id(), tag_map));
     }
-    
+
     // Issue-003: Continue with existing intersection_area validation
     if (tagged_area_id == lanelet::InvalId) {
       continue;

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_tagging.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_tagging.cpp
@@ -65,12 +65,21 @@ TEST_F(TestIntersectionAreaTaggingValidator, MissingIntersectionAreaTag)  // NOL
 
   std::map<std::string, std::string> area_id_map;
   area_id_map["area_id"] = std::to_string(expected_area_id);
-  const auto expected_issue =
+  const auto expected_issue1 =
     construct_issue_from_code(issue_code(test_target_, 1), expected_lanelet_id, area_id_map);
+  std::map<std::string, std::string> turn_direction_map;
+  turn_direction_map["turn_direction"] = "straight";
+  const auto expected_issue2 =
+    construct_issue_from_code(issue_code(test_target_, 4), expected_lanelet_id, turn_direction_map);
 
-  const auto difference = compare_an_issue(expected_issue, issues[0]);
-  EXPECT_TRUE(difference.empty()) << difference;
+  lanelet::validation::Issues expected_issues;
+  expected_issues.push_back(expected_issue1);
+  expected_issues.push_back(expected_issue2);
+
+  const auto differences = compare_issues(expected_issues, issues);
+  EXPECT_TRUE(differences.empty()) << differences;
   EXPECT_EQ(issues[0].id, expected_lanelet_id);
+  EXPECT_EQ(issues[1].id, expected_lanelet_id);
 }
 
 TEST_F(TestIntersectionAreaTaggingValidator, IncorrectIntersectionAreaTag)  // NOLINT for gtest

--- a/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_tagging.cpp
+++ b/autoware_lanelet2_map_validator/test/src/intersection/test_intersection_area_tagging.cpp
@@ -58,7 +58,7 @@ TEST_F(TestIntersectionAreaTaggingValidator, MissingIntersectionAreaTag)  // NOL
   lanelet::autoware::validation::IntersectionAreaTaggingValidator checker;
   const auto & issues = checker(*map_);
 
-  EXPECT_EQ(issues.size(), 1);
+  EXPECT_EQ(issues.size(), 2);
 
   const lanelet::Id expected_lanelet_id = 49;
   const lanelet::Id expected_area_id = 10803;


### PR DESCRIPTION
## Description

Added validation for lanelets with `turn_direction` tags to ensure they also have `intersection_area` tags. This enhancement improves intersection tagging consistency by detecting cases where lanelets have turn direction information but are missing the required intersection area reference.

### Validation subjects
Lanelets that have a `turn_direction` tag

### What is validated
This validator checks if lanelets with `turn_direction` tags also have the required `intersection_area` tag set.

### Added files
Modified files:
- intersection_area_tagging.cpp
- intersection_area_tagging.md
- test_intersection_area_tagging.cpp
- issues_info.json
- sample_map.osm (test data)

### Added issue codes:
- Intersection.IntersectionAreaTagging-004

## How was this PR tested?
Unit test.

## Notes for reviewers

None.

## Effects on system behavior

None.
