### PR TITLE
feat: add text window for lat, lon when utm or transverse_mercator is selected

### DIFF
--- a/autoware_lanelet2_map_validator/gui/gui.py
+++ b/autoware_lanelet2_map_validator/gui/gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2025 TIER IV, Inc.
+# Copyright 2025-2026 TIER IV, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
 from gui_helper import DropLineEdit
+from gui_helper import get_map_bounds_from_osm
 from gui_helper import run_lanelet2_validator
 from map_visualizer import MapVisualizerWidget
 
@@ -216,7 +217,53 @@ class ValidatorUI(QMainWindow):
         self.language_combo.addItems(["en", "ja"])
         opts_grid.addWidget(self.language_combo, 0, 3)
 
-        # Visualize map checkbox (row 1)
+        self._origin_lat_label = QLabel("Origin latitude:")
+        self.lat_edit = QLineEdit()
+        self.lat_edit.setPlaceholderText("WGS84, e.g. 35.681236 (optional: filled from map on Run)")
+        self.lat_edit.setToolTip(
+            "For UTM and Transverse Mercator. Leave empty to estimate map center from OSM when "
+            "you press Start Validation."
+        )
+        self._origin_lon_label = QLabel("Origin longitude:")
+        self.lon_edit = QLineEdit()
+        self.lon_edit.setPlaceholderText(
+            "WGS84, e.g. 139.767125 (optional: filled from map on Run)"
+        )
+        self.lon_edit.setToolTip(
+            "For UTM and Transverse Mercator. Leave empty to estimate map center from OSM when "
+            "you press Start Validation."
+        )
+        self.origin_estimate_label = QLabel()
+        self.origin_estimate_label.setWordWrap(True)
+        self.origin_estimate_label.setVisible(False)
+        self.origin_estimate_label.setStyleSheet(
+            "color: #b45309; font-size: 12px; padding-top: 4px;"
+        )
+
+        lat_row = QHBoxLayout()
+        lat_row.setSpacing(8)
+        lat_row.addWidget(self._origin_lat_label)
+        lat_row.addWidget(self.lat_edit, 1)
+
+        lon_row = QHBoxLayout()
+        lon_row.setSpacing(8)
+        lon_row.addWidget(self._origin_lon_label)
+        lon_row.addWidget(self.lon_edit, 1)
+
+        origin_inner = QVBoxLayout()
+        origin_inner.setSpacing(6)
+        origin_inner.setContentsMargins(0, 0, 0, 0)
+        origin_inner.addLayout(lat_row)
+        origin_inner.addLayout(lon_row)
+        origin_inner.addWidget(self.origin_estimate_label)
+
+        self._origin_container = QWidget()
+        self._origin_container.setLayout(origin_inner)
+        opts_grid.addWidget(self._origin_container, 1, 0, 1, 4)
+
+        self._projector_origin_widgets = [self._origin_container]
+
+        # Visualize map checkbox (below lat/lon)
         self.visualize_map_checkbox = QCheckBox("Visualize map")
         self.visualize_map_checkbox.setObjectName("visualize_map_checkbox")
         self.visualize_map_checkbox.setChecked(True)
@@ -237,7 +284,10 @@ class ValidatorUI(QMainWindow):
         """
         )
         self.visualize_map_checkbox.stateChanged.connect(self.toggle_map_visualization)
-        opts_grid.addWidget(self.visualize_map_checkbox, 1, 0, 1, 2)
+        opts_grid.addWidget(self.visualize_map_checkbox, 2, 0, 1, 4)
+
+        self.projector_combo.currentTextChanged.connect(self.on_projector_type_changed)
+        self.on_projector_type_changed()
 
         input_panel.addWidget(opts_group)
 
@@ -277,6 +327,11 @@ Parameter YAML              Path to the YAML file where a list of
 Projector (-p arg)          Projector used for loading lanelet map.
                             Available projectors are: mgrs, utm,
                             transverse_mercator. (default: mgrs)
+----------------------------------------------------------------------------------
+lat / lon (--lat, --lon)    Map origin in WGS84 degrees. Required by the CLI
+                            for utm / transverse_mercator. In the GUI, if you
+                            leave them empty, the map center is estimated from
+                            OSM nodes when you press Start Validation.
 ----------------------------------------------------------------------------------
 language (-l arg)           Language to display the issue messages. Available
                             languare are: jp, en. (default: en)
@@ -516,6 +571,40 @@ language (-l arg)           Language to display the issue messages. Available
         self.tab_widget.setTabPosition(QTabWidget.North)
         self.setCentralWidget(central)
 
+    def on_projector_type_changed(self, _text: str | None = None) -> None:
+        show = self.projector_combo.currentText() in ("utm", "transverse_mercator")
+        for w in self._projector_origin_widgets:
+            w.setVisible(show)
+        if not show:
+            self.origin_estimate_label.setVisible(False)
+            self.origin_estimate_label.clear()
+
+    def estimate_origin_from_osm(self, osm_path: str) -> tuple[float | None, float | None]:
+        """Return map center (lat, lon) from OSM node bounds, or (None, None) if unavailable."""
+        if not osm_path or not os.path.exists(osm_path):
+            return None, None
+        min_lon, min_lat, max_lon, max_lat = get_map_bounds_from_osm(osm_path)
+        if min_lon is None or min_lat is None or max_lon is None or max_lat is None:
+            return None, None
+        clat = (min_lat + max_lat) / 2.0
+        clon = (min_lon + max_lon) / 2.0
+        return clat, clon
+
+    def parse_origin_lat_lon(self) -> tuple[float | None, float | None]:
+        lat_s = self.lat_edit.text().strip()
+        lon_s = self.lon_edit.text().strip()
+        if not lat_s or not lon_s:
+            return None, None
+        try:
+            return float(lat_s), float(lon_s)
+        except ValueError:
+            return None, None
+
+    def get_origin_for_map_load(self) -> tuple[float | None, float | None]:
+        if self.projector_combo.currentText() not in ("utm", "transverse_mercator"):
+            return None, None
+        return self.parse_origin_lat_lon()
+
     def toggle_map_visualization(self, state):
         """Toggle map visualization without removing the tab."""
         if state == Qt.Checked:
@@ -523,8 +612,9 @@ language (-l arg)           Language to display the issue messages. Available
             osm_path = self.osm_edit.text().strip()
             if osm_path and os.path.exists(osm_path):
                 projector = self.projector_combo.currentText()
+                olat, olon = self.get_origin_for_map_load()
                 try:
-                    self.map_visualizer.load_map_file(osm_path, projector)
+                    self.map_visualizer.load_map_file(osm_path, projector, olat, olon)
                 except Exception as e:
                     print(f"Error reloading map for visualization: {e}")
                     self.map_visualizer.map_info_label.setText(f"Error loading map: {str(e)}")
@@ -729,6 +819,58 @@ language (-l arg)           Language to display the issue messages. Available
             self.tab_widget.setCurrentWidget(self.error_tab)
             return
 
+        origin_lat: float | None = None
+        origin_lon: float | None = None
+        used_estimated_origin = False
+        if projector in ("utm", "transverse_mercator"):
+            self.origin_estimate_label.setVisible(False)
+            self.origin_estimate_label.clear()
+
+            lat_s = self.lat_edit.text().strip()
+            lon_s = self.lon_edit.text().strip()
+
+            if lat_s and lon_s:
+                origin_lat, origin_lon = self.parse_origin_lat_lon()
+                if origin_lat is None or origin_lon is None:
+                    self.error_content = (
+                        '<span style="color:red">For UTM and Transverse Mercator, enter valid '
+                        "numeric latitude and longitude (WGS84 degrees), or leave both empty "
+                        "to estimate from the map on Run.</span>"
+                    )
+                    self.error_tab.setHtml(self.error_content)
+                    self.warn_tab.clear()
+                    self.tab_widget.setCurrentWidget(self.error_tab)
+                    return
+            elif not lat_s and not lon_s:
+                est_lat, est_lon = self.estimate_origin_from_osm(osm_path)
+                if est_lat is None or est_lon is None:
+                    self.error_content = (
+                        '<span style="color:red">For UTM and Transverse Mercator, enter '
+                        "latitude and longitude, or ensure the OSM file contains nodes with "
+                        "lat/lon so the map center can be estimated.</span>"
+                    )
+                    self.error_tab.setHtml(self.error_content)
+                    self.warn_tab.clear()
+                    self.tab_widget.setCurrentWidget(self.error_tab)
+                    return
+                origin_lat, origin_lon = est_lat, est_lon
+                self.lat_edit.setText(f"{origin_lat:.8f}")
+                self.lon_edit.setText(f"{origin_lon:.8f}")
+                used_estimated_origin = True
+                self.origin_estimate_label.setText(
+                    "Lat/Lon is not input, an estimated value is used instead."
+                )
+                self.origin_estimate_label.setVisible(True)
+            else:
+                self.error_content = (
+                    '<span style="color:red">Enter both latitude and longitude, or leave both '
+                    "empty to estimate from the map.</span>"
+                )
+                self.error_tab.setHtml(self.error_content)
+                self.warn_tab.clear()
+                self.tab_widget.setCurrentWidget(self.error_tab)
+                return
+
         if output_dir:
             output_file = os.path.join(output_dir, "lanelet2_validation_results.json")
             existed_before = os.path.exists(output_file)
@@ -736,7 +878,7 @@ language (-l arg)           Language to display the issue messages. Available
         try:
             if self.visualize_map_checkbox.isChecked():
                 try:
-                    self.map_visualizer.load_map_file(osm_path, projector)
+                    self.map_visualizer.load_map_file(osm_path, projector, origin_lat, origin_lon)
                 except Exception as e:
                     print(f"Error loading map for visualization: {e}")
                     self.map_visualizer.map_info_label.setText(f"Error loading map: {str(e)}")
@@ -752,6 +894,8 @@ language (-l arg)           Language to display the issue messages. Available
                 output_dir=Path(output_dir) if output_dir else None,
                 language=language,
                 validator_filter=validator_filter if validator_filter else None,
+                origin_lat=origin_lat,
+                origin_lon=origin_lon,
             )
 
             # Populate errors
@@ -780,6 +924,11 @@ language (-l arg)           Language to display the issue messages. Available
 
             # Populate warnings
             warn_html = []
+            if used_estimated_origin:
+                warn_html.append(
+                    '<span style="color:#b45309">Lat/Lon is not input, and estimated value is '
+                    "used instead.</span><br/>"
+                )
             for line in out_lines:
                 if line.lower().startswith("warning"):
                     if ":" in line:
@@ -940,11 +1089,12 @@ language (-l arg)           Language to display the issue messages. Available
                 # Load the current map file into the visualizer if not already loaded
                 osm_path = self.osm_edit.text().strip()
                 projector_type = self.projector_combo.currentText()
+                olat, olon = self.get_origin_for_map_load()
                 if osm_path and os.path.exists(osm_path):
                     if self.map_visualizer.current_file != osm_path:
                         # Load the map file with the selected projector
                         try:
-                            self.map_visualizer.load_map_file(osm_path, projector_type)
+                            self.map_visualizer.load_map_file(osm_path, projector_type, olat, olon)
                         except Exception as e:
                             print(f"Error loading map for visualization: {e}")
 

--- a/autoware_lanelet2_map_validator/gui/gui.py
+++ b/autoware_lanelet2_map_validator/gui/gui.py
@@ -586,9 +586,9 @@ language (-l arg)           Language to display the issue messages. Available
         min_lon, min_lat, max_lon, max_lat = get_map_bounds_from_osm(osm_path)
         if min_lon is None or min_lat is None or max_lon is None or max_lat is None:
             return None, None
-        clat = (min_lat + max_lat) / 2.0
-        clon = (min_lon + max_lon) / 2.0
-        return clat, clon
+        center_lat = (min_lat + max_lat) / 2.0
+        center_lon = (min_lon + max_lon) / 2.0
+        return center_lat, center_lon
 
     def parse_origin_lat_lon(self) -> tuple[float | None, float | None]:
         lat_s = self.lat_edit.text().strip()
@@ -612,9 +612,9 @@ language (-l arg)           Language to display the issue messages. Available
             osm_path = self.osm_edit.text().strip()
             if osm_path and os.path.exists(osm_path):
                 projector = self.projector_combo.currentText()
-                olat, olon = self.get_origin_for_map_load()
+                origin_lat, origin_lon = self.get_origin_for_map_load()
                 try:
-                    self.map_visualizer.load_map_file(osm_path, projector, olat, olon)
+                    self.map_visualizer.load_map_file(osm_path, projector, origin_lat, origin_lon)
                 except Exception as e:
                     print(f"Error reloading map for visualization: {e}")
                     self.map_visualizer.map_info_label.setText(f"Error loading map: {str(e)}")
@@ -1089,12 +1089,14 @@ language (-l arg)           Language to display the issue messages. Available
                 # Load the current map file into the visualizer if not already loaded
                 osm_path = self.osm_edit.text().strip()
                 projector_type = self.projector_combo.currentText()
-                olat, olon = self.get_origin_for_map_load()
+                origin_lat, origin_lon = self.get_origin_for_map_load()
                 if osm_path and os.path.exists(osm_path):
                     if self.map_visualizer.current_file != osm_path:
                         # Load the map file with the selected projector
                         try:
-                            self.map_visualizer.load_map_file(osm_path, projector_type, olat, olon)
+                            self.map_visualizer.load_map_file(
+                                osm_path, projector_type, origin_lat, origin_lon
+                            )
                         except Exception as e:
                             print(f"Error loading map for visualization: {e}")
 

--- a/autoware_lanelet2_map_validator/gui/gui_helper.py
+++ b/autoware_lanelet2_map_validator/gui/gui_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2025 TIER IV, Inc.
+# Copyright 2025-2026 TIER IV, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 from pathlib import Path
 import subprocess
 from typing import List
+from typing import Optional
 from typing import Tuple
 import xml.etree.ElementTree as ET
 
@@ -83,8 +84,23 @@ def get_map_bounds_from_osm(osm_file: str) -> Tuple[float, float, float, float]:
         return None, None, None, None
 
 
-def create_appropriate_projector(osm_file: str, projector_type: str = "utm"):
+def create_appropriate_projector(
+    osm_file: str,
+    projector_type: str = "utm",
+    origin_lat: Optional[float] = None,
+    origin_lon: Optional[float] = None,
+):
     """Create an appropriate projector based on the map's location and selected projector type."""
+    use_explicit_origin = (
+        origin_lat is not None
+        and origin_lon is not None
+        and projector_type in ("utm", "transverse_mercator")
+    )
+    if use_explicit_origin:
+        center_lat, center_lon = origin_lat, origin_lon
+        utm_zone = get_utm_zone_from_longitude(center_lon)
+        return UtmProjector(Origin(center_lat, center_lon), utm_zone, center_lat >= 0)
+
     min_lon, min_lat, max_lon, max_lat = get_map_bounds_from_osm(osm_file)
 
     if min_lon is not None and max_lon is not None and min_lat is not None and max_lat is not None:
@@ -122,6 +138,8 @@ def run_lanelet2_validator(
     output_dir: Path = None,
     language: str = "en",
     validator_filter: str = "",
+    origin_lat: Optional[float] = None,
+    origin_lon: Optional[float] = None,
 ) -> Tuple[int, List[str], List[str]]:
     """Run the Lanelet2 validator with the specified parameters."""
     cmd = [
@@ -136,6 +154,13 @@ def run_lanelet2_validator(
         "-l",
         language,
     ]
+
+    if projector in ("utm", "transverse_mercator"):
+        if origin_lat is None or origin_lon is None:
+            raise ValueError(
+                "origin_lat and origin_lon are required for utm and transverse_mercator projectors"
+            )
+        cmd += ["--lat", str(origin_lat), "--lon", str(origin_lon)]
 
     if exclusion_file:
         cmd += ["-x", str(exclusion_file)]

--- a/autoware_lanelet2_map_validator/gui/map_validator_gui.spec
+++ b/autoware_lanelet2_map_validator/gui/map_validator_gui.spec
@@ -44,6 +44,9 @@ hiddenimports = [
     'matplotlib_widget',
     'lanelet2',
     'autoware_lanelet2_extension_python.projection',
+    # distutils removed in Python 3.12; matplotlib may import distutils.version
+    'setuptools._distutils',
+    'setuptools._distutils.version',
 ]
 tmp_ret = collect_all('PySide6-essential')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
@@ -56,7 +59,7 @@ a = Analysis(
     hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=[os.path.join(spec_dir, 'pyi_rth_distutils.py')],
     excludes=[],
     noarchive=False,
     optimize=0,

--- a/autoware_lanelet2_map_validator/gui/map_visualizer.py
+++ b/autoware_lanelet2_map_validator/gui/map_visualizer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2025 TIER IV, Inc.
+# Copyright 2025-2026 TIER IV, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 """Map visualizer widget using matplotlib and lanelet2."""
+from __future__ import annotations
+
 import os
 import sys
 
@@ -176,10 +178,18 @@ class MapVisualizerWidget(QWidget):
             self.canvas.set_zoom_level(value)
             self.zoom_label.setText(f"{value}%")
 
-    def load_map_file(self, file_path: str, projector_type: str = "utm"):
+    def load_map_file(
+        self,
+        file_path: str,
+        projector_type: str = "utm",
+        origin_lat: float | None = None,
+        origin_lon: float | None = None,
+    ):
         """Load a specific OSM map file with given projector type."""
         try:
-            projector = create_appropriate_projector(file_path, projector_type)
+            projector = create_appropriate_projector(
+                file_path, projector_type, origin_lat=origin_lat, origin_lon=origin_lon
+            )
             self.lanelet_map = load(file_path, projector)
             self.current_file = file_path
 

--- a/autoware_lanelet2_map_validator/gui/matplotlib_widget.py
+++ b/autoware_lanelet2_map_validator/gui/matplotlib_widget.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2025 TIER IV, Inc.
+# Copyright 2025-2026 TIER IV, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/autoware_lanelet2_map_validator/gui/pyi_rth_distutils.py
+++ b/autoware_lanelet2_map_validator/gui/pyi_rth_distutils.py
@@ -1,0 +1,45 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyInstaller runtime hook: make ``distutils.version`` importable for matplotlib.
+
+CPython 3.12+ removed ``distutils`` from the standard library. Setuptools still
+provides it via ``setuptools._distutils``, but that shim is not always active
+before bundled code imports ``distutils.version`` (e.g. some matplotlib
+versions). Register the modules in ``sys.modules`` before the main script runs.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _install_distutils_shim() -> None:
+    if "distutils.version" in sys.modules:
+        return
+    try:
+        import setuptools  # noqa: F401 — must load before distutils (setuptools hack)
+        import setuptools._distutils as _distutils
+    except ImportError:
+        return
+    sys.modules.setdefault("distutils", _distutils)
+    try:
+        from setuptools._distutils import version as _version
+
+        sys.modules["distutils.version"] = _version
+    except ImportError:
+        pass
+
+
+_install_distutils_shim()

--- a/autoware_lanelet2_map_validator/gui/requirements.txt
+++ b/autoware_lanelet2_map_validator/gui/requirements.txt
@@ -1,3 +1,4 @@
 pyside6-essentials>=6.9.1
 matplotlib>=3.10.3
 numpy>=1.26.4
+setuptools>=65.0.0


### PR DESCRIPTION
## Description

Currently, there is no window to input `lat` and `lon` of the map origin when `utm` and `transverse_mercator` is selected as a projector.

This PR adds a text window to input `lat` and `lon` when certain projectors are selected.
Plus, I also added a feature that when the user pressed `Run Validator` with blank lat/lon, the GUI will calculate and set the map center as a temporary origin to perform validation.

### Fig. 1 When `utm` is selected

<img width="1380" height="874" alt="image" src="https://github.com/user-attachments/assets/8be91b87-0b41-473f-97ab-d41c542ebee6" />

### Fig. 2 When "Run Validator" is run with blank lat/lon

<img width="1407" height="874" alt="image" src="https://github.com/user-attachments/assets/c8fac22c-0afa-42af-a6ed-489f1694ce10" />

## How was this PR tested?

- Checked that `ros2 run autoware_lanelet2_map_validator gui.py` works with the added feature.
- Tried to build the GUI by `pyinstaller map_validator_gui.spec --clean` and checked that `./dist/map_validator_gui` works with the added feature.

I used the GUI several times against some maps.

## Notes for reviewers

None.

## Effects on system behavior

None.
