### PR TITLE
ci: centralize static-build overlays and validate on PR

### DIFF
--- a/.github/scripts/apply-static-build-overlays.sh
+++ b/.github/scripts/apply-static-build-overlays.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Single source of truth for static-build cherry-picks used by release and validate workflows.
+# Run from repository root after checking out the release tag (detached HEAD is fine).
+set -euo pipefail
+
+CATEGORY="${1:-}"
+if [[ ${CATEGORY} != "before_or_equal_1_5_2" && ${CATEGORY} != "after_1_5_2" ]]; then
+    echo "Usage: $0 before_or_equal_1_5_2|after_1_5_2" >&2
+    exit 1
+fi
+
+ROOT="${GITHUB_WORKSPACE:-}"
+if [[ -z ${ROOT} ]]; then
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z ${ROOT} || ! -d "${ROOT}/.git" ]]; then
+    echo "Could not determine repository root (set GITHUB_WORKSPACE or run inside a git clone)." >&2
+    exit 1
+fi
+cd "${ROOT}"
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git fetch origin main
+# Not on main but required for cherry-pick objects
+git fetch origin c8192e2311785a21894d7311f079b28caa541ca5
+
+case "${CATEGORY}" in
+before_or_equal_1_5_2)
+    git cherry-pick b92492bb2232f0c1d502cfc0c6aede2f3169116b
+    git cherry-pick 8ed41f2f8d59d63c09bb47ac8ad59d4f56c7d07c
+    git cherry-pick 36c5e266dbf2bba0df39a7f789615fa4a2ecb8c3
+    git cherry-pick c8192e2311785a21894d7311f079b28caa541ca5
+    ;;
+after_1_5_2)
+    git cherry-pick c8192e2311785a21894d7311f079b28caa541ca5
+    ;;
+esac

--- a/.github/workflows/build-and-upload-binaries.yaml
+++ b/.github/workflows/build-and-upload-binaries.yaml
@@ -7,13 +7,56 @@ on:
         description: The name of the tag to build and upload binaries for
         type: string
         required: true
+      dry-run:
+        description: If true, build but skip GPG signing and GitHub release upload
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      category: ${{ steps.parse.outputs.category }}
+    steps:
+      - name: Get Release Version
+        id: parse
+        run: |
+          REF_NAME="${{ github.event.inputs.tag-name }}"
+          VERSION=${REF_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Split into major, minor, patch
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Default values to 0 if missing
+          MAJOR=${MAJOR:-0}
+          MINOR=${MINOR:-0}
+          PATCH=${PATCH:-0}
+
+          # Reference version 1.5.2
+          REF_MAJOR=1
+          REF_MINOR=5
+          REF_PATCH=2
+
+          # Compare version parts
+          if (( MAJOR < REF_MAJOR )) || \
+             (( MAJOR == REF_MAJOR && MINOR < REF_MINOR )) || \
+             (( MAJOR == REF_MAJOR && MINOR == REF_MINOR && PATCH <= REF_PATCH )); then
+            CATEGORY="before_or_equal_1_5_2"
+          else
+            CATEGORY="after_1_5_2"
+          fi
+
+          echo "Category: $CATEGORY"
+          echo "category=$CATEGORY" >> "$GITHUB_OUTPUT"
+
   build-gui:
     runs-on: ubuntu-22.04
+    needs: [setup]
     container:
       image: ghcr.io/autowarefoundation/autoware:core-devel
       options: --user root
@@ -23,11 +66,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: static_build_helper
+          ref: ${{ needs.setup.outputs.version }}
 
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Apply static-build overlays
+        shell: bash
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/scripts/apply-static-build-overlays.sh" "${{ needs.setup.outputs.category }}"
 
       - name: Build validator GUI
         id: build_gui
@@ -70,65 +118,18 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
-    needs: [build-gui]
+    needs: [setup, build-gui]
 
     steps:
-      - name: Get Release Version
-        id: get_version
-        run: |
-          REF_NAME="${{ github.event.inputs.tag-name }}"
-          VERSION=${REF_NAME#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Split into major, minor, patch
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-
-          # Default values to 0 if missing
-          MAJOR=${MAJOR:-0}
-          MINOR=${MINOR:-0}
-          PATCH=${PATCH:-0}
-
-          # Reference version 1.5.2
-          REF_MAJOR=1
-          REF_MINOR=5
-          REF_PATCH=2
-
-          # Compare version parts
-          if (( MAJOR < REF_MAJOR )) || \
-             (( MAJOR == REF_MAJOR && MINOR < REF_MINOR )) || \
-             (( MAJOR == REF_MAJOR && MINOR == REF_MINOR && PATCH <= REF_PATCH )); then
-            CATEGORY="before_or_equal_1_5_2"
-          else
-            CATEGORY="after_1_5_2"
-          fi
-
-          echo "Category: $CATEGORY"
-          echo "category=$CATEGORY" >> "$GITHUB_OUTPUT"
-
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.get_version.outputs.version }}
+          ref: ${{ needs.setup.outputs.version }}
 
-      - name: Cherry-pick preparation
+      - name: Apply static-build overlays
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main static_build_helper
-
-      - name: cherry-pick for version <= 1.5.2
-        if: steps.get_version.outputs.category == 'before_or_equal_1_5_2'
-        run: |
-          git cherry-pick b92492bb2232f0c1d502cfc0c6aede2f3169116b
-          git cherry-pick 8ed41f2f8d59d63c09bb47ac8ad59d4f56c7d07c
-          git cherry-pick 36c5e266dbf2bba0df39a7f789615fa4a2ecb8c3
-          git cherry-pick c8192e2311785a21894d7311f079b28caa541ca5
-
-      - name: cherry-pick for version > 1.5.2
-        if: steps.get_version.outputs.category == 'after_1_5_2'
-        run: |
-          git cherry-pick c8192e2311785a21894d7311f079b28caa541ca5
+          bash "$GITHUB_WORKSPACE/.github/scripts/apply-static-build-overlays.sh" "${{ needs.setup.outputs.category }}"
 
       - name: Install Dependencies
         run: |
@@ -261,7 +262,7 @@ jobs:
       - name: Package artifacts
         id: package
         run: |
-          VERSION=${{ steps.get_version.outputs.version }}
+          VERSION=${{ needs.setup.outputs.version }}
           ZIP_NAME="autoware_lanelet2_map_validator-${VERSION}-linux-x86_64.zip"
           mkdir release_package
 
@@ -285,12 +286,14 @@ jobs:
 
       - name: Sign the package with GPG
         id: gpg-sign
+        if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
           gpg --batch --yes --detach-sign --armor --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" -o ${{ steps.package.outputs.zip_name }}.asc ${{ steps.package.outputs.zip_name }}
           echo "signature_name=${{ steps.package.outputs.zip_name }}.asc" >> $GITHUB_OUTPUT
 
       - name: Install GitHub CLI
+        if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |
           (type -p wget >/dev/null || (sudo apt-get update && sudo apt-get install wget -y))
           sudo mkdir -p -m 755 /etc/apt/keyrings
@@ -301,10 +304,17 @@ jobs:
           sudo apt-get install gh -y
 
       - name: Upload artifacts to GitHub Release
+        if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |
-          gh release upload "${{ steps.get_version.outputs.version }}" \
+          gh release upload "${{ needs.setup.outputs.version }}" \
             "${{ steps.package.outputs.zip_name }}" \
             "${{ steps.gpg-sign.outputs.signature_name }}" \
             --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dry run summary
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        run: |
+          echo "Dry run: built ${{ steps.package.outputs.zip_name }} (not signed, not uploaded)."
+          ls -la "${{ steps.package.outputs.zip_name }}" || true

--- a/.github/workflows/validate-release-overlays.yaml
+++ b/.github/workflows/validate-release-overlays.yaml
@@ -1,0 +1,57 @@
+name: validate-release-overlays
+
+# Fails if static-build cherry-picks no longer apply to pinned release tags.
+# Update matrix tag_ref values when dropping support for a release line.
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/apply-static-build-overlays.sh
+      - .github/workflows/build-and-upload-binaries.yaml
+      - .github/workflows/validate-release-overlays.yaml
+      - .github/cmake/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/scripts/apply-static-build-overlays.sh
+      - .github/workflows/build-and-upload-binaries.yaml
+      - .github/workflows/validate-release-overlays.yaml
+      - .github/cmake/**
+
+permissions:
+  contents: read
+
+jobs:
+  overlay:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: legacy_tag
+            tag_ref: 1.5.2
+            category: before_or_equal_1_5_2
+          - label: modern_tag
+            tag_ref: 1.6.0
+            category: after_1_5_2
+    steps:
+      - name: Check out PR head (for overlay script)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Save overlay script from branch under test
+        run: |
+          cp .github/scripts/apply-static-build-overlays.sh /tmp/apply-static-build-overlays.sh
+          chmod +x /tmp/apply-static-build-overlays.sh
+
+      - name: Fetch release tag and detach
+        run: |
+          git fetch origin "+refs/tags/${{ matrix.tag_ref }}:refs/tags/${{ matrix.tag_ref }}"
+          git checkout --detach "${{ matrix.tag_ref }}"
+
+      - name: Apply overlays (script from PR / push commit)
+        run: |
+          /tmp/apply-static-build-overlays.sh "${{ matrix.category }}"


### PR DESCRIPTION
## Description

This PR refactors and improves the current build-and-upload procedure.

- Add apply-static-build-overlays.sh as single source for fetch + cherry-picks
- setup job + same tag ref for GUI/CLI; run overlay script in both jobs before build
- Add validate-release-overlays workflow (matrix on tags 1.5.2 / 1.6.0)
- Add optional dry-run workflow_dispatch input (skip GPG + gh upload)

Made-with: Cursor

## How was this PR tested?

Actually this PR has to be merged once to test.

## Notes for reviewers

I will bypass merge this PR.

## Effects on system behavior

None.
