### PR TITLE
ci: materialize overlay script from workflow SHA after tag checkout

### DIFF
--- a/.github/workflows/build-and-upload-binaries.yaml
+++ b/.github/workflows/build-and-upload-binaries.yaml
@@ -68,6 +68,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
 
+      - name: Materialize overlay script from workflow ref
+        shell: bash
+        run: |
+          set -e
+          # Release tags predate this script; always take the definition from the commit that runs the workflow.
+          git fetch origin "${{ github.sha }}"
+          mkdir -p .github/scripts
+          git show "${{ github.sha }}:.github/scripts/apply-static-build-overlays.sh" > .github/scripts/apply-static-build-overlays.sh
+          chmod +x .github/scripts/apply-static-build-overlays.sh
+
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
@@ -126,6 +136,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
+
+      - name: Materialize overlay script from workflow ref
+        run: |
+          set -e
+          git fetch origin "${{ github.sha }}"
+          mkdir -p .github/scripts
+          git show "${{ github.sha }}:.github/scripts/apply-static-build-overlays.sh" > .github/scripts/apply-static-build-overlays.sh
+          chmod +x .github/scripts/apply-static-build-overlays.sh
 
       - name: Apply static-build overlays
         run: |


### PR DESCRIPTION
## Description

Old release tags do not contain apply-static-build-overlays.sh; fetch github.sha and extract the script before cherry-picks in build-gui and build.

Made-with: Cursor

## How was this PR tested?

## Notes for reviewers

I'll bypass merge this one.

## Effects on system behavior

None.
