### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/autoware_lanelet2_map_validator/CHANGELOG.rst
+++ b/autoware_lanelet2_map_validator/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package autoware_lanelet2_map_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.7.0 (2026-04-21)
+------------------
+* feat: manage map requirements by diffs (`#162 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/162>`_)
+* fix: relieve the condition for BufferZoneValidity-003 (`#161 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/161>`_)
+* feat: add text window for lat, lon when utm or transverse_mercator is selected (`#158 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/158>`_)
+* fix: move autoware_lanelet2_extension_python to exec_depend (`#157 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/157>`_)
+* Contributors: Taiki Yamada
+
 1.6.0 (2026-01-30)
 ------------------
 * chore: add vm-01-05 to map requirements (`#155 <https://github.com/tier4/autoware_lanelet2_map_validator/issues/155>`_)

--- a/autoware_lanelet2_map_validator/package.xml
+++ b/autoware_lanelet2_map_validator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lanelet2_map_validator</name>
-  <version>1.6.0</version>
+  <version>1.7.0</version>
   <description>Validation tool for lanelet2 maps especially for Autoware usage</description>
   <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>


### PR DESCRIPTION
## Description

Bump version to 1.7.0.

The changes are quite subtle compared to 1.6.0 so a patch bump was also considered, but since the directory structure in the `map_requirements` changes I decided to make this bump as a minor bump.

## How was this PR tested?

Check that the 

## Notes for reviewers

I'll bypass merge this PR after the CI got passed.

## Effects on system behavior

None.
