### PR TITLE
fix: set safe workspace on workflow

### DIFF
--- a/.github/workflows/build-and-upload-binaries.yaml
+++ b/.github/workflows/build-and-upload-binaries.yaml
@@ -147,13 +147,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
 
-<<<<<<< HEAD
       - name: Configure Git safe directory
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-=======
->>>>>>> 49edbb5 (ci: materialize overlay script from workflow SHA after tag checkout (#160))
       - name: Materialize overlay script from workflow ref
         run: |
           set -e

--- a/.github/workflows/build-and-upload-binaries.yaml
+++ b/.github/workflows/build-and-upload-binaries.yaml
@@ -68,6 +68,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
 
+      - name: Configure Git Safe Directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Materialize overlay script from workflow ref
         shell: bash
         run: |
@@ -77,10 +81,6 @@ jobs:
           mkdir -p .github/scripts
           git show "${{ github.sha }}:.github/scripts/apply-static-build-overlays.sh" > .github/scripts/apply-static-build-overlays.sh
           chmod +x .github/scripts/apply-static-build-overlays.sh
-
-      - name: Configure Git Safe Directory
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Apply static-build overlays
         shell: bash
@@ -136,6 +136,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Materialize overlay script from workflow ref
         run: |

--- a/.github/workflows/build-and-upload-binaries.yaml
+++ b/.github/workflows/build-and-upload-binaries.yaml
@@ -68,6 +68,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
 
+      - name: Materialize overlay script from workflow ref
+        shell: bash
+        run: |
+          set -e
+          # Release tags predate this script; always take the definition from the commit that runs the workflow.
+          git fetch origin "${{ github.sha }}"
+          mkdir -p .github/scripts
+          git show "${{ github.sha }}:.github/scripts/apply-static-build-overlays.sh" > .github/scripts/apply-static-build-overlays.sh
+          chmod +x .github/scripts/apply-static-build-overlays.sh
+
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -137,10 +147,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.version }}
 
+<<<<<<< HEAD
       - name: Configure Git safe directory
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+=======
+>>>>>>> 49edbb5 (ci: materialize overlay script from workflow SHA after tag checkout (#160))
       - name: Materialize overlay script from workflow ref
         run: |
           set -e


### PR DESCRIPTION
## Description

fix the issue of 
```
fatal: detected dubious ownership in repository at '/__w/autoware_lanelet2_map_validator/autoware_lanelet2_map_validator'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/autoware_lanelet2_map_validator/autoware_lanelet2_map_validator
Error: Process completed with exit code 128.
```

in build-and-upload-binaries.yaml

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
