### PR TITLE
chore(road_shoulder): discontinue Lane.RoadShoulder-002

### DIFF
--- a/autoware_lanelet2_map_validator/docs/lane/road_shoulder.md
+++ b/autoware_lanelet2_map_validator/docs/lane/road_shoulder.md
@@ -11,13 +11,11 @@ This validator implements the VM-01-15 requirement for road shoulder lanelets. I
 The validator specifically checks:
 
 - That road shoulder lanelets have at least one adjacent lanelet
-- That adjacent lanelets have the proper 'road' subtype when a road shoulder has only one adjacent lanelet
 - That the outer boundary of a road shoulder (the side without an adjacent lanelet) is properly marked as a 'road_border'
 
 | Issue Code            | Message                                                                    | Severity | Primitive  | Description                                                                            | Approach                                                                   |
 | --------------------- | -------------------------------------------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | Lane.RoadShoulder-001 | Road shoulder lanelet has no adjacent lanelets.                            | Error    | Lanelet    | Road shoulder lanelets must have at least one adjacent lanelet.                        | Check if a road shoulder has at least one adjacent lanelet on either side. |
-| Lane.RoadShoulder-002 | Road shoulders must be adjacent to at least one road subtype lanelet.      | Error    | Lanelet    | If a road shoulder has only one adjacent lanelet, it must be a road subtype.           | Check that the single adjacent lanelet has a 'road' subtype.               |
 | Lane.RoadShoulder-003 | The empty side of the lanelet bound must be a road_border type linestring. | Error    | LineString | If a road shoulder has an empty side, the boundary on that side must be a road_border. | Check that the boundary on the empty side has a 'road_border' type.        |
 
 ## Parameters
@@ -28,3 +26,11 @@ None.
 
 - road_shoulder.cpp
 - road_shoulder.hpp
+
+## Discontinued issues
+
+Some issues are currently discontinued.
+
+| Issue Code            | Message                                                               | Severity | Primitive | Description                                                                                             | Approach                                                     |
+| --------------------- | --------------------------------------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Lane.RoadShoulder-002 | Road shoulders must be adjacent to at least one road subtype lanelet. | Error    | Lanelet   | If a road shoulder has only one adjacent lanelet, it must be a road subtype. (Used until version 1.7.0) | Check that the single adjacent lanelet has a 'road' subtype. |

--- a/autoware_lanelet2_map_validator/src/validators/lane/road_shoulder.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/lane/road_shoulder.cpp
@@ -75,16 +75,6 @@ lanelet::validation::Issues RoadShoulderValidator::check_road_shoulder(
     }
 
     if (has_left != has_right) {
-      // Issue-002: Check if adjacent lanelet is a road
-      const auto & adjacent_lanelets = has_left ? left_lanelets : right_lanelets;
-      const auto & adjacent = adjacent_lanelets.value();
-      const auto & adj_attrs = adjacent.attributes();
-      const auto & adj_subtype_it = adj_attrs.find(lanelet::AttributeName::Subtype);
-
-      if (adj_subtype_it == adj_attrs.end() || adj_subtype_it->second != "road") {
-        issues.push_back(construct_issue_from_code(issue_code(this->name(), 2), lanelet.id()));
-      }
-
       // Issue-003: Check if empty side bound is road_border
       const auto & empty_side_bound = has_left ? lanelet.rightBound() : lanelet.leftBound();
       const auto & bound_attrs = empty_side_bound.attributes();

--- a/autoware_lanelet2_map_validator/test/src/lane/test_road_shoulder.cpp
+++ b/autoware_lanelet2_map_validator/test/src/lane/test_road_shoulder.cpp
@@ -64,20 +64,6 @@ TEST_F(TestRoadShoulderValidator, NoAdjacentLanelets)  // NOLINT for gtest
   EXPECT_TRUE(difference.empty()) << difference;
 }
 
-TEST_F(TestRoadShoulderValidator, NonRoadAdjacentLanelet)  // NOLINT for gtest
-{
-  load_target_map("lane/shoulder_road_with_non_road_adjacent.osm");
-
-  lanelet::autoware::validation::RoadShoulderValidator checker;
-  const auto & issues = checker(*map_);
-
-  EXPECT_EQ(issues.size(), 1);
-  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 2), 23);
-
-  const auto difference = compare_an_issue(expected_issue, issues[0]);
-  EXPECT_TRUE(difference.empty()) << difference;
-}
-
 TEST_F(TestRoadShoulderValidator, NoRoadBorderBound)  // NOLINT for gtest
 {
   load_target_map("lane/shoulder_road_empty_side_no_road_border.osm");


### PR DESCRIPTION
## Description

Discontinue Lane.RoadShoulder-002 since this issue conflicts with the fact that `bicycle_lane` can be put between a `road` and a `road_shoulder`.

## How was this PR tested?

Confirmed that `colcon test` works.

## Notes for reviewers

None.

## Effects on system behavior

None.
