### PR TITLE
feat(traffic_light_facing): add facing validation for pedestrian signals

### DIFF
--- a/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/traffic_light/traffic_light_facing.hpp
+++ b/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/traffic_light/traffic_light_facing.hpp
@@ -46,6 +46,12 @@ private:
    */
   bool is_red_yellow_green_traffic_light(const lanelet::ConstLineString3d & linestring);
 
+  bool is_red_green_traffic_light(const lanelet::ConstLineString3d & linestring);
+
+  bool is_pedestrian_traffic_light_facing_correct(
+    const lanelet::ConstLineString3d & pedestrian_traffic_light,
+    const lanelet::ConstLanelet & crosswalk_lanelet);
+
   /**
    * @brief Convert lanelet::ConstLineString3d to a Eigen::Vector3d.
    * The linestring must be made only from two points.

--- a/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
@@ -75,14 +75,28 @@ lanelet::validation::Issues TrafficLightFacingValidator::check_traffic_light_fac
     }
 
     lanelet::Optional<lanelet::ConstLineString3d> stop_line = tl_reg_elem->stopLine();
-    if (!stop_line) {
-      // This case should be filtered out by mapping.traffic_light.regulatory_element_details
-      continue;
-    }
 
     for (const lanelet::ConstLineString3d & refers_linestring :
          tl_reg_elem->getParameters<lanelet::ConstLineString3d>(lanelet::RoleName::Refers)) {
+      if (is_red_green_traffic_light(refers_linestring)) {
+        traffic_light_facing_status.insert({refers_linestring.id(), NOT_EXAMINED});
+        for (const lanelet::ConstLanelet & crosswalk_lanelet :
+             map.laneletLayer.findUsages(tl_reg_elem)) {
+          if (is_pedestrian_traffic_light_facing_correct(refers_linestring, crosswalk_lanelet)) {
+            traffic_light_facing_status[refers_linestring.id()] |= FOUND_CORRECT;
+          } else {
+            traffic_light_facing_status[refers_linestring.id()] |= FOUND_WRONG;
+          }
+        }
+        continue;
+      }
+
       if (!is_red_yellow_green_traffic_light(refers_linestring)) {
+        continue;
+      }
+
+      if (!stop_line) {
+        // This case should be filtered out by mapping.traffic_light.regulatory_element_details
         continue;
       }
 

--- a/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
@@ -169,7 +169,8 @@ bool TrafficLightFacingValidator::is_red_green_traffic_light(
          linestring.hasAttribute(lanelet::AttributeName::Subtype) &&
          linestring.attribute(lanelet::AttributeName::Type).value() ==
            lanelet::AttributeValueString::TrafficLight &&
-         linestring.attribute(lanelet::AttributeName::Subtype).value() == "red_green";
+         linestring.attribute(lanelet::AttributeName::Subtype).value() ==
+           lanelet::AttributeValueString::RedGreen;
 }
 
 bool TrafficLightFacingValidator::is_pedestrian_traffic_light_facing_correct(

--- a/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
@@ -176,24 +176,18 @@ bool TrafficLightFacingValidator::is_pedestrian_traffic_light_facing_correct(
   const lanelet::ConstLineString3d & pedestrian_traffic_light,
   const lanelet::ConstLanelet & crosswalk_lanelet)
 {
-  const Eigen::Vector2d start_xy(
-    pedestrian_traffic_light.front().x(), pedestrian_traffic_light.front().y());
-  const Eigen::Vector2d end_xy(
-    pedestrian_traffic_light.back().x(), pedestrian_traffic_light.back().y());
-  const Eigen::Vector2d v1 = end_xy - start_xy;
+  Eigen::Vector2d start_xy = pedestrian_traffic_light.front().basicPoint().head<2>();
+  Eigen::Vector2d end_xy = pedestrian_traffic_light.back().basicPoint().head<2>();
+  Eigen::Vector2d v_light = end_xy - start_xy;
 
-  const auto & left_bound = crosswalk_lanelet.leftBound();
-  const auto & right_bound = crosswalk_lanelet.rightBound();
-  const Eigen::Vector2d midpoint_xy =
-    (Eigen::Vector2d(left_bound.front().x(), left_bound.front().y()) +
-     Eigen::Vector2d(left_bound.back().x(), left_bound.back().y()) +
-     Eigen::Vector2d(right_bound.front().x(), right_bound.front().y()) +
-     Eigen::Vector2d(right_bound.back().x(), right_bound.back().y())) /
-    4.0;
+  Eigen::Vector2d midpoint_xy = (crosswalk_lanelet.leftBound().front().basicPoint().head<2>() +
+                                 crosswalk_lanelet.leftBound().back().basicPoint().head<2>() +
+                                 crosswalk_lanelet.rightBound().front().basicPoint().head<2>() +
+                                 crosswalk_lanelet.rightBound().back().basicPoint().head<2>()) /
+                                4.0;
+  Eigen::Vector2d v_mid = midpoint_xy - start_xy;
 
-  const Eigen::Vector2d v2 = midpoint_xy - start_xy;
-
-  const double cross_z = v1.x() * v2.y() - v1.y() * v2.x();
+  double cross_z = v_light.x() * v_mid.y() - v_light.y() * v_mid.x();
   return cross_z < 0.0;
 }
 

--- a/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/traffic_light/traffic_light_facing.cpp
@@ -148,6 +148,41 @@ bool TrafficLightFacingValidator::is_red_yellow_green_traffic_light(
            lanelet::AttributeValueString::RedYellowGreen;
 }
 
+bool TrafficLightFacingValidator::is_red_green_traffic_light(
+  const lanelet::ConstLineString3d & linestring)
+{
+  return linestring.hasAttribute(lanelet::AttributeName::Type) &&
+         linestring.hasAttribute(lanelet::AttributeName::Subtype) &&
+         linestring.attribute(lanelet::AttributeName::Type).value() ==
+           lanelet::AttributeValueString::TrafficLight &&
+         linestring.attribute(lanelet::AttributeName::Subtype).value() == "red_green";
+}
+
+bool TrafficLightFacingValidator::is_pedestrian_traffic_light_facing_correct(
+  const lanelet::ConstLineString3d & pedestrian_traffic_light,
+  const lanelet::ConstLanelet & crosswalk_lanelet)
+{
+  const Eigen::Vector2d start_xy(
+    pedestrian_traffic_light.front().x(), pedestrian_traffic_light.front().y());
+  const Eigen::Vector2d end_xy(
+    pedestrian_traffic_light.back().x(), pedestrian_traffic_light.back().y());
+  const Eigen::Vector2d v1 = end_xy - start_xy;
+
+  const auto & left_bound = crosswalk_lanelet.leftBound();
+  const auto & right_bound = crosswalk_lanelet.rightBound();
+  const Eigen::Vector2d midpoint_xy =
+    (Eigen::Vector2d(left_bound.front().x(), left_bound.front().y()) +
+     Eigen::Vector2d(left_bound.back().x(), left_bound.back().y()) +
+     Eigen::Vector2d(right_bound.front().x(), right_bound.front().y()) +
+     Eigen::Vector2d(right_bound.back().x(), right_bound.back().y())) /
+    4.0;
+
+  const Eigen::Vector2d v2 = midpoint_xy - start_xy;
+
+  const double cross_z = v1.x() * v2.y() - v1.y() * v2.x();
+  return cross_z < 0.0;
+}
+
 lanelet::LineString3d TrafficLightFacingValidator::get_starting_edge_from_lanelet(
   const lanelet::ConstLanelet & lanelet, const lanelet::ConstLineString3d & reference)
 {

--- a/autoware_lanelet2_map_validator/test/data/map/traffic_light/crosswalk_with_wrong_pedestrian_traffic_light_facing.osm
+++ b/autoware_lanelet2_map_validator/test/data/map/traffic_light/crosswalk_with_wrong_pedestrian_traffic_light_facing.osm
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="6" validation_version="1" />
+  <node id="285" lat="35.90327302784" lon="139.9336616108">
+    <tag k="local_x" v="3774.4814" />
+    <tag k="local_y" v="73745.2383" />
+    <tag k="ele" v="19.267" />
+  </node>
+  <node id="287" lat="35.90324402805" lon="139.93364250018">
+    <tag k="local_x" v="3772.7217" />
+    <tag k="local_y" v="73742.0405" />
+    <tag k="ele" v="19.273" />
+  </node>
+  <node id="423" lat="35.90333113903" lon="139.93358580547">
+    <tag k="local_x" v="3767.7109" />
+    <tag k="local_y" v="73751.7586" />
+    <tag k="ele" v="19.226" />
+  </node>
+  <node id="425" lat="35.90332841683" lon="139.93362555503">
+    <tag k="local_x" v="3771.2947" />
+    <tag k="local_y" v="73751.4175" />
+    <tag k="ele" v="19.253" />
+  </node>
+  <node id="8935" lat="35.90333041537" lon="139.93361395716">
+    <tag k="local_x" v="3770.2505" />
+    <tag k="local_y" v="73751.6506" />
+    <tag k="ele" v="22.115" />
+  </node>
+  <node id="8936" lat="35.90333181916" lon="139.93361863457">
+    <tag k="local_x" v="3770.6743" />
+    <tag k="local_y" v="73751.8017" />
+    <tag k="ele" v="22.115" />
+  </node>
+  <node id="10285" lat="35.90327302784" lon="139.9338816108">
+    <tag k="local_x" v="3794.4814" />
+    <tag k="local_y" v="73745.2383" />
+    <tag k="ele" v="19.267" />
+  </node>
+  <node id="10287" lat="35.90324402805" lon="139.93386250018">
+    <tag k="local_x" v="3792.7217" />
+    <tag k="local_y" v="73742.0405" />
+    <tag k="ele" v="19.273" />
+  </node>
+  <node id="10423" lat="35.90333113903" lon="139.93380580547">
+    <tag k="local_x" v="3787.7109" />
+    <tag k="local_y" v="73751.7586" />
+    <tag k="ele" v="19.226" />
+  </node>
+  <node id="10425" lat="35.90333241683" lon="139.93384555503">
+    <tag k="local_x" v="3791.2947" />
+    <tag k="local_y" v="73751.4175" />
+    <tag k="ele" v="19.253" />
+  </node>
+  <node id="18935" lat="35.90333041537" lon="139.93383395716">
+    <tag k="local_x" v="3790.2505" />
+    <tag k="local_y" v="73751.6506" />
+    <tag k="ele" v="22.115" />
+  </node>
+  <node id="18936" lat="35.90333181916" lon="139.93383863457">
+    <tag k="local_x" v="3790.6743" />
+    <tag k="local_y" v="73751.8017" />
+    <tag k="ele" v="22.115" />
+  </node>
+  <way id="331">
+    <nd ref="423" />
+    <nd ref="287" />
+    <tag k="type" v="line_thin" />
+  </way>
+  <way id="332">
+    <nd ref="425" />
+    <nd ref="285" />
+    <tag k="type" v="line_thin" />
+  </way>
+  <way id="410">
+    <nd ref="8935" />
+    <nd ref="8936" />
+    <tag k="type" v="traffic_light" />
+    <tag k="subtype" v="red_green" />
+    <tag k="height" v="0.5" />
+  </way>
+  <way id="10331">
+    <nd ref="10423" />
+    <nd ref="10287" />
+    <tag k="type" v="line_thin" />
+  </way>
+  <way id="10332">
+    <nd ref="10425" />
+    <nd ref="10285" />
+    <tag k="type" v="line_thin" />
+  </way>
+  <way id="999">
+    <nd ref="18936" />
+    <nd ref="18935" />
+    <tag k="type" v="traffic_light" />
+    <tag k="subtype" v="red_green" />
+    <tag k="height" v="0.5" />
+  </way>
+  <relation id="166">
+    <member type="way" role="left" ref="331" />
+    <member type="way" role="right" ref="332" />
+    <member type="relation" role="regulatory_element" ref="9838" />
+    <member type="relation" role="regulatory_element" ref="20001" />
+    <tag k="type" v="lanelet" />
+    <tag k="subtype" v="crosswalk" />
+    <tag k="speed_limit" v="30" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="participant:pedestrian" v="yes" />
+  </relation>
+  <relation id="9998">
+    <member type="way" role="left" ref="10331" />
+    <member type="way" role="right" ref="10332" />
+    <member type="relation" role="regulatory_element" ref="9999" />
+    <member type="relation" role="regulatory_element" ref="20002" />
+    <tag k="type" v="lanelet" />
+    <tag k="subtype" v="crosswalk" />
+    <tag k="speed_limit" v="30" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="participant:pedestrian" v="yes" />
+  </relation>
+  <relation id="9838">
+    <member type="way" role="refers" ref="410" />
+    <tag k="type" v="regulatory_element" />
+    <tag k="subtype" v="traffic_light" />
+  </relation>
+  <relation id="9999">
+    <member type="way" role="refers" ref="999" />
+    <tag k="type" v="regulatory_element" />
+    <tag k="subtype" v="traffic_light" />
+  </relation>
+  <relation id="20001">
+    <member type="relation" role="refers" ref="166" />
+    <tag k="type" v="regulatory_element" />
+    <tag k="subtype" v="crosswalk" />
+  </relation>
+  <relation id="20002">
+    <member type="relation" role="refers" ref="9998" />
+    <tag k="type" v="regulatory_element" />
+    <tag k="subtype" v="crosswalk" />
+  </relation>
+</osm>

--- a/autoware_lanelet2_map_validator/test/src/traffic_light/test_traffic_light_facing.cpp
+++ b/autoware_lanelet2_map_validator/test/src/traffic_light/test_traffic_light_facing.cpp
@@ -97,6 +97,21 @@ TEST_F(TestTrafficLightFacing, CorrectFacing)  // NOLINT for gtest
   EXPECT_EQ(issues.size(), 0);
 }
 
+TEST_F(TestTrafficLightFacing, WrongPedestrianTrafficLightFacing)  // NOLINT for gtest
+{
+  load_target_map("traffic_light/crosswalk_with_wrong_pedestrian_traffic_light_facing.osm");
+
+  lanelet::autoware::validation::TrafficLightFacingValidator checker;
+  const auto & issues = checker(*map_);
+
+  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 2), 999);
+
+  EXPECT_EQ(issues.size(), 1);
+
+  const auto difference = compare_an_issue(expected_issue, issues[0]);
+  EXPECT_TRUE(difference.empty()) << difference;
+}
+
 TEST_F(TestTrafficLightFacing, SampleMap)  // NOLINT for gtest
 {
   load_target_map("sample_map.osm");


### PR DESCRIPTION
## Description
This PR implements the facing direction validation for pedestrian traffic lights (`subtype: red_green`), which were previously skipped (`continue;`) in the `traffic_light_facing` validator.

According to the [Pilot.Auto vector map requirements (vm-04-02)](https://docs.pilot.auto/reference-design/common/map-requirements/vector-map-requirements/category_traffic_light/#vm-04-02-%E4%BF%A1%E5%8F%B7%E6%A9%9F%E3%81%AE%E4%BD%8D%E7%BD%AE%E3%81%A8%E3%82%B5%E3%82%A4%E3%82%BA), the `traffic_light` linestring is drawn from left to right from the viewer's perspective. This validation checks if the signal is facing the crosswalk correctly by calculating the 2D cross product of:
1. The directional vector of the pedestrian signal linestring (`start` -> `end`).
2. The vector from the signal's `start` point to the approximated midpoint of the referenced `crosswalk` lanelet.

If the cross product is negative (`< 0.0`), the crosswalk correctly lies on the front side of the signal (the right side of the left-to-right signal vector).

## Changes
* **Added pedestrian signal identification**: Created the `is_red_green_traffic_light()` helper.
* **Added cross-product validation**: Implemented the `is_pedestrian_traffic_light_facing_correct()` function to handle the 2D mathematical directional check.
* **Updated main validation loop**: Integrated the pedestrian validation branch into `check_traffic_light_facing()`, reusing the `FOUND_WRONG` / `FOUND_AMBIGUOUS` issue emission logic.
* **Adjusted `stop_line` logic**: Moved the `!stop_line` existence check inside the vehicle (`red_yellow_green`) branch within `check_traffic_light_facing()`. This ensures that pedestrian regulatory elements, which legitimately operate without stop lines, are properly evaluated.