### PR TITLE
chore: remove intersection_lanelet_border_type from vm-03-02 and reconstruct map_requirements

### DIFF
--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_2_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2024_7_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2025_3_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/cargo_transport-v2025_6_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/common.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_44_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_45_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_46_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/robo_taxi-v0_47_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v2_3_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v3_1_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v4_0_1.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.2/shuttle_bus-v4_1_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2024_2_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2024_7_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2025_3_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/cargo_transport-v2025_6_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/common.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_44_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_45_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_46_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_47_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/robo_taxi-v0_48_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v2_3_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v3_0_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v3_1_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_0_1.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_1_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.3/shuttle_bus-v4_2_0.json
@@ -113,9 +113,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2024_2_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2024_7_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_3_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_6_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_8_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/cargo_transport-v2025_8_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/common.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_44_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_45_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_46_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_47_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_48_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_50_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/robo_taxi-v0_50_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v2_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v3_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v3_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_0_1.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_2_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.4/shuttle_bus-v4_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2024_2_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2024_7_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_3_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_6_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_8_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/cargo_transport-v2025_8_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/common.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_44_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_45_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_46_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_47_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_48_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_50_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_50_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_52_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/robo_taxi-v0_52_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v2_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v3_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v3_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_0_1.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_2_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v4_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v5_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.5/shuttle_bus-v5_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2024_2_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2024_7_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_11_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_11_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_11_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_11_1.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_3_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_6_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_8_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/cargo_transport-v2025_8_0.json
@@ -62,9 +62,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/common.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_44_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_45_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_46_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_47_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_48_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_50_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_50_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_52_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/robo_taxi-v0_52_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v2_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v3_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v3_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_0_1.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_1_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_2_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v4_3_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v5_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.6/shuttle_bus-v5_0_0.json
@@ -105,9 +105,6 @@
       "validators": [
         {
           "name": "mapping.intersection.turn_direction_tagging"
-        },
-        {
-          "name": "mapping.intersection.lanelet_border_type"
         }
       ]
     },

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2024_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2024_2_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2024_7_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2024_7_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_11_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_11_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_11_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_11_1.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_3_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_6_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_6_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_8_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/cargo_transport-v2025_8_0.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/common.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/common.json
@@ -1,0 +1,279 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-02",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/delivery_robot-v0_39_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/delivery_robot-v0_39_0.json
@@ -1,0 +1,93 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/delivery_robot-v2023_10_2.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/delivery_robot-v2023_10_2.json
@@ -1,0 +1,93 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-16",
+      "validators": [
+        {
+          "name": "mapping.intersection.regulatory_element_details_for_virtual_traffic_lights"
+        },
+        {
+          "name": "mapping.intersection.virtual_traffic_light_line_order"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-17",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_for_virtual_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-18",
+      "validators": [
+        {
+          "name": "mapping.intersection.virtual_traffic_light_section_overlap",
+          "prerequisites": [
+            {
+              "name": "mapping.intersection.virtual_traffic_light_line_order"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_44_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_44_0_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_45_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_45_0_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_46_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_46_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_47_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_47_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_48_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_48_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_50_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_50_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_51_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_51_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_52_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/robo_taxi-v0_52_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v2_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v2_3_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v3_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v3_0_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v3_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v3_1_0.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_0_1.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_0_1.json
@@ -1,0 +1,239 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_1_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_1_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_2_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_2_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_3_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v4_3_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v5_0_0.json
+++ b/autoware_lanelet2_map_validator/map_requirements/pilot-auto/v1.0.7/shuttle_bus-v5_0_0.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0.7",
+  "requirements": [
+    {
+      "id": "vm-01-01",
+      "validators": [
+        {
+          "name": "mapping.lane.road_lanelet_attribute"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-03_vm-01-04",
+      "validators": [
+        {
+          "name": "mapping.lane.border_sharing"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-05",
+      "validators": [
+        {
+          "name": "mapping.lane.lanelet_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-09",
+      "validators": [
+        {
+          "name": "mapping.lane.speed_limit_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-10",
+      "validators": [
+        {
+          "name": "mapping.lane.centerline_geometry"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-15",
+      "validators": [
+        {
+          "name": "mapping.lane.road_shoulder"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-17",
+      "validators": [
+        {
+          "name": "mapping.lane.pedestrian_lane"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-19",
+      "validators": [
+        {
+          "name": "mapping.lane.walkway_intersection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-20",
+      "validators": [
+        {
+          "name": "mapping.lane.lateral_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-01-21",
+      "validators": [
+        {
+          "name": "mapping.lane.longitudinal_subtype_connection"
+        }
+      ]
+    },
+    {
+      "id": "vm-02-04",
+      "validators": [
+        {
+          "name": "mapping.stop_line.missing_regulatory_elements"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-01",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_dangling_reference"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-02",
+      "validators": [
+        {
+          "name": "mapping.intersection.turn_direction_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-05",
+      "validators": [
+        {
+          "name": "mapping.intersection.lanelet_division"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-08",
+      "validators": [
+        {
+          "name": "mapping.intersection.intersection_area_validity"
+        },
+        {
+          "name": "mapping.intersection.intersection_area_segment_type"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-10",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_with_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-11",
+      "validators": [
+        {
+          "name": "mapping.intersection.right_of_way_without_traffic_lights"
+        }
+      ]
+    },
+    {
+      "id": "vm-03-14",
+      "validators": [
+        {
+          "name": "mapping.intersection.road_markings"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-01",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.traffic_light.missing_referrers"
+        },
+        {
+          "name": "mapping.traffic_light.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-02",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.correct_facing"
+        },
+        {
+          "name": "mapping.traffic_light.body_height"
+        }
+      ]
+    },
+    {
+      "id": "vm-04-03",
+      "validators": [
+        {
+          "name": "mapping.traffic_light.light_bulb_tagging"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-01",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.missing_regulatory_elements"
+        },
+        {
+          "name": "mapping.crosswalk.regulatory_element_details"
+        }
+      ]
+    },
+    {
+      "id": "vm-05-03",
+      "validators": [
+        {
+          "name": "mapping.crosswalk.safety_attributes"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-01",
+      "validators": [
+        {
+          "name": "mapping.area.buffer_zone_validity"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-02",
+      "validators": [
+        {
+          "name": "mapping.area.no_parking_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-04",
+      "validators": [
+        {
+          "name": "mapping.area.no_stopping_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-05",
+      "validators": [
+        {
+          "name": "mapping.area.detection_area"
+        }
+      ]
+    },
+    {
+      "id": "vm-06-06",
+      "validators": [
+        {
+          "name": "mapping.area.missing_regulatory_elements_for_bus_stop_areas"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/pilot_auto_map_requirements/fragments/vm-03-02.json
+++ b/tools/pilot_auto_map_requirements/fragments/vm-03-02.json
@@ -3,9 +3,6 @@
   "validators": [
     {
       "name": "mapping.intersection.turn_direction_tagging"
-    },
-    {
-      "name": "mapping.intersection.lanelet_border_type"
     }
   ]
 }

--- a/tools/pilot_auto_map_requirements/generate_pilot_auto_map_requirements.py
+++ b/tools/pilot_auto_map_requirements/generate_pilot_auto_map_requirements.py
@@ -58,7 +58,7 @@ from typing import Any
 # Relative paths under tools/pilot_auto_map_requirements/
 # Subdirectory under map_requirements/pilot-auto/ for the current shipped bundle
 # (must match JSON top-level "version" / bundle era; also written to index.json).
-CURRENT_REQUIREMENT_BUNDLE_DIRECTORY = "v1.0.6"
+CURRENT_REQUIREMENT_BUNDLE_DIRECTORY = "v1.0.7"
 
 GROUP_INDEX_PATH = "index.json"
 GROUP_FILE_BY_ID: dict[str, str] = {

--- a/tools/pilot_auto_map_requirements/groups/cargo_transport.json
+++ b/tools/pilot_auto_map_requirements/groups/cargo_transport.json
@@ -220,6 +220,62 @@
       "path": "v1.0.6/cargo_transport-v2025_11_1.json",
       "version": "1.0.6",
       "patches": []
+    },
+
+    {
+      "path": "v1.0.7/cargo_transport-v2024_2_0.json",
+      "version": "1.0.7",
+      "requirement_ids": [
+        "vm-01-01",
+        "vm-01-05",
+        "vm-01-09",
+        "vm-01-10",
+        "vm-01-20",
+        "vm-01-21",
+        "vm-02-02",
+        "vm-03-02",
+        "vm-03-16",
+        "vm-03-17",
+        "vm-03-18",
+        "vm-06-02",
+        "vm-06-05"
+      ]
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2024_2_0.json",
+      "path": "v1.0.7/cargo_transport-v2024_7_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2024_7_0.json",
+      "path": "v1.0.7/cargo_transport-v2025_3_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2025_3_0.json",
+      "path": "v1.0.7/cargo_transport-v2025_6_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2025_6_0.json",
+      "path": "v1.0.7/cargo_transport-v2025_8_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2025_8_0.json",
+      "path": "v1.0.7/cargo_transport-v2025_11_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/cargo_transport-v2025_11_0.json",
+      "path": "v1.0.7/cargo_transport-v2025_11_1.json",
+      "version": "1.0.7",
+      "patches": []
     }
   ]
 }

--- a/tools/pilot_auto_map_requirements/groups/common.json
+++ b/tools/pilot_auto_map_requirements/groups/common.json
@@ -67,6 +67,12 @@
       "version": "1.0.6",
       "extends": "v1.0.5/common.json",
       "patches": []
+    },
+    {
+      "path": "v1.0.7/common.json",
+      "version": "1.0.7",
+      "extends": "v1.0.6/common.json",
+      "patches": []
     }
   ]
 }

--- a/tools/pilot_auto_map_requirements/groups/delivery_robot.json
+++ b/tools/pilot_auto_map_requirements/groups/delivery_robot.json
@@ -103,6 +103,29 @@
       "path": "v1.0.6/delivery_robot-v0_39_0.json",
       "version": "1.0.6",
       "patches": []
+    },
+
+    {
+      "path": "v1.0.7/delivery_robot-v2023_10_2.json",
+      "version": "1.0.7",
+      "requirement_ids": [
+        "vm-01-01",
+        "vm-01-09",
+        "vm-01-10",
+        "vm-01-20",
+        "vm-01-21",
+        "vm-02-04",
+        "vm-03-16",
+        "vm-03-17",
+        "vm-03-18",
+        "vm-06-05"
+      ]
+    },
+    {
+      "extends": "v1.0.7/delivery_robot-v2023_10_2.json",
+      "path": "v1.0.7/delivery_robot-v0_39_0.json",
+      "version": "1.0.7",
+      "patches": []
     }
   ]
 }

--- a/tools/pilot_auto_map_requirements/groups/robo_taxi.json
+++ b/tools/pilot_auto_map_requirements/groups/robo_taxi.json
@@ -328,6 +328,86 @@
       "path": "v1.0.6/robo_taxi-v0_52_0.json",
       "version": "1.0.6",
       "patches": []
+    },
+
+    {
+      "path": "v1.0.7/robo_taxi-v0_44_0_0.json",
+      "version": "1.0.7",
+      "requirement_ids": [
+        "vm-01-01",
+        "vm-01-03_vm-01-04",
+        "vm-01-05",
+        "vm-01-09",
+        "vm-01-10",
+        "vm-01-15",
+        "vm-01-17",
+        "vm-01-19",
+        "vm-01-20",
+        "vm-01-21",
+        "vm-02-04",
+        "vm-03-01",
+        "vm-03-02",
+        "vm-03-05",
+        "vm-03-08",
+        "vm-03-10",
+        "vm-03-11",
+        "vm-03-14",
+        "vm-04-01",
+        "vm-04-02",
+        "vm-04-03",
+        "vm-05-01",
+        "vm-05-03",
+        "vm-06-01",
+        "vm-06-02",
+        "vm-06-04",
+        "vm-06-05"
+      ]
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_44_0_0.json",
+      "path": "v1.0.7/robo_taxi-v0_45_0_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_45_0_0.json",
+      "path": "v1.0.7/robo_taxi-v0_46_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_46_0.json",
+      "path": "v1.0.7/robo_taxi-v0_47_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.5/robo_taxi-v0_47_0.json",
+      "path": "v1.0.7/robo_taxi-v0_48_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_48_0.json",
+      "path": "v1.0.7/robo_taxi-v0_50_0.json",
+      "version": "1.0.7",
+      "patches": [
+        {
+          "append_ids": ["vm-06-06"]
+        }
+      ]
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_50_0.json",
+      "path": "v1.0.7/robo_taxi-v0_51_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/robo_taxi-v0_51_0.json",
+      "path": "v1.0.7/robo_taxi-v0_52_0.json",
+      "version": "1.0.7",
+      "patches": []
     }
   ]
 }

--- a/tools/pilot_auto_map_requirements/groups/shuttle_bus.json
+++ b/tools/pilot_auto_map_requirements/groups/shuttle_bus.json
@@ -366,6 +366,86 @@
       "path": "v1.0.6/shuttle_bus-v5_0_0.json",
       "version": "1.0.6",
       "patches": []
+    },
+
+    {
+      "path": "v1.0.7/shuttle_bus-v2_3_0.json",
+      "version": "1.0.7",
+      "requirement_ids": [
+        "vm-01-01",
+        "vm-01-03_vm-01-04",
+        "vm-01-05",
+        "vm-01-09",
+        "vm-01-10",
+        "vm-01-15",
+        "vm-01-17",
+        "vm-01-19",
+        "vm-01-20",
+        "vm-01-21",
+        "vm-02-04",
+        "vm-03-01",
+        "vm-03-02",
+        "vm-03-05",
+        "vm-03-08",
+        "vm-03-10",
+        "vm-03-11",
+        "vm-03-14",
+        "vm-04-01",
+        "vm-04-02",
+        "vm-04-03",
+        "vm-05-01",
+        "vm-05-03",
+        "vm-06-01",
+        "vm-06-02",
+        "vm-06-04",
+        "vm-06-05"
+      ]
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v2_3_0.json",
+      "path": "v1.0.7/shuttle_bus-v3_0_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v3_0_0.json",
+      "path": "v1.0.7/shuttle_bus-v3_1_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v3_1_0.json",
+      "path": "v1.0.7/shuttle_bus-v4_0_1.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v4_0_1.json",
+      "path": "v1.0.7/shuttle_bus-v4_1_0.json",
+      "version": "1.0.7",
+      "patches": [
+        {
+          "append_ids": ["vm-06-06"]
+        }
+      ]
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v4_1_0.json",
+      "path": "v1.0.7/shuttle_bus-v4_2_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v4_2_0.json",
+      "path": "v1.0.7/shuttle_bus-v4_3_0.json",
+      "version": "1.0.7",
+      "patches": []
+    },
+    {
+      "extends": "v1.0.7/shuttle_bus-v4_3_0.json",
+      "path": "v1.0.7/shuttle_bus-v5_0_0.json",
+      "version": "1.0.7",
+      "patches": []
     }
   ]
 }


### PR DESCRIPTION
## Description

- Removes `mapping.intersection.lanelet_border_type` from map_requirement `vm-03-02`
- Add new map requirement files for v1.0.7

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
