### PR TITLE
chore: discontinue Lane.PedestrianLane-002

### DIFF
--- a/autoware_lanelet2_map_validator/docs/lane/pedestrian_lane.md
+++ b/autoware_lanelet2_map_validator/docs/lane/pedestrian_lane.md
@@ -9,15 +9,13 @@ mapping.lane.pedestrian_lane
 This validator checks the validity of pedestrian_lane subtype lanelets. It validates:
 
 1. Whether the lanelet has at least one adjacent lanelet
-2. If there is only one adjacent lanelet, checks whether it is a road subtype lanelet
-3. If there is an empty side (no adjacent lanelet), checks whether the bound linestring has a road_border type
+2. If there is an empty side (no adjacent lanelet), checks whether the bound linestring has a road_border type
 
 The validator uses the "validator" traffic rule to determine adjacency relationships through the routing graph.
 
 | Issue Code              | Message                                                            | Severity | Primitive  | Description                                                                                                                                       | Approach                                                                              |
 | ----------------------- | ------------------------------------------------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | Lane.PedestrianLane-001 | Pedestrian lane must have at least one adjacent lanelet.           | Error    | Lanelet    | The pedestrian lane has no adjacent lanelets on either side, which violates the requirement that pedestrian lanes should be adjacent to roadways. | Add appropriate adjacent lanelets or reconsider the pedestrian lane placement.        |
-| Lane.PedestrianLane-002 | Adjacent lanelet must be a road subtype lanelet.                   | Error    | Lanelet    | The pedestrian lane has only one adjacent lanelet, but it is not of road subtype. Pedestrian lanes should be adjacent to road lanelets.           | Ensure the adjacent lanelet has subtype="road" or add appropriate road lanelets.      |
 | Lane.PedestrianLane-003 | The bound linestring on the empty side must have road_border type. | Error    | LineString | When a pedestrian lane has only one adjacent lanelet, the boundary on the empty side should be marked as road_border to indicate the road edge.   | Set the type attribute of the boundary linestring on the empty side to "road_border". |
 
 ## Parameters
@@ -28,3 +26,11 @@ None.
 
 - pedestrian_lane.cpp
 - pedestrian_lane.hpp
+
+## Discontinued issues
+
+Some issues are currently discontinued.
+
+| Issue Code              | Message                                          | Severity | Primitive | Description                                                                                                                                                        | Approach                                                                         |
+| ----------------------- | ------------------------------------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| Lane.PedestrianLane-002 | Adjacent lanelet must be a road subtype lanelet. | Error    | Lanelet   | The pedestrian lane has only one adjacent lanelet, but it is not of road subtype. Pedestrian lanes should be adjacent to road lanelets. (Used until version 1.7.0) | Ensure the adjacent lanelet has subtype="road" or add appropriate road lanelets. |

--- a/autoware_lanelet2_map_validator/src/validators/lane/pedestrian_lane.cpp
+++ b/autoware_lanelet2_map_validator/src/validators/lane/pedestrian_lane.cpp
@@ -75,16 +75,6 @@ lanelet::validation::Issues PedestrianLaneValidator::check_pedestrian_lane(
     }
 
     if (has_left != has_right) {
-      // Issue-002: Check if adjacent lanelet is a road
-      const auto & adjacent_lanelets = has_left ? left_lanelets : right_lanelets;
-      const auto & adjacent = adjacent_lanelets.value();
-      const auto & adj_attrs = adjacent.attributes();
-      const auto & adj_subtype_it = adj_attrs.find(lanelet::AttributeName::Subtype);
-
-      if (adj_subtype_it == adj_attrs.end() || adj_subtype_it->second != "road") {
-        issues.push_back(construct_issue_from_code(issue_code(this->name(), 2), lanelet.id()));
-      }
-
       // Issue-003: Check if empty side bound is road_border
       const auto & empty_side_bound = has_left ? lanelet.rightBound() : lanelet.leftBound();
       const auto & bound_attrs = empty_side_bound.attributes();

--- a/autoware_lanelet2_map_validator/test/src/lane/test_pedestrian_lane.cpp
+++ b/autoware_lanelet2_map_validator/test/src/lane/test_pedestrian_lane.cpp
@@ -64,20 +64,6 @@ TEST_F(TestPedestrianLaneValidator, NoAdjacentLanelets)  // NOLINT for gtest
   EXPECT_TRUE(difference.empty()) << difference;
 }
 
-TEST_F(TestPedestrianLaneValidator, NonRoadAdjacentLanelet)  // NOLINT for gtest
-{
-  load_target_map("lane/pedestrian_lane_with_non_road_adjacent.osm");
-
-  lanelet::autoware::validation::PedestrianLaneValidator checker;
-  const auto & issues = checker(*map_);
-
-  ASSERT_EQ(issues.size(), 1);
-  const auto expected_issue = construct_issue_from_code(issue_code(test_target_, 2), 23);
-
-  const auto difference = compare_an_issue(expected_issue, issues[0]);
-  EXPECT_TRUE(difference.empty()) << difference;
-}
-
 TEST_F(TestPedestrianLaneValidator, NoRoadBorderBound)  // NOLINT for gtest
 {
   load_target_map("lane/pedestrian_lane_empty_side_no_road_border.osm");


### PR DESCRIPTION
## Description

Discontinue Lane.PedestrianLane-002 since pedestrian_lanes don't have to be aside of a road always.

## How was this PR tested?

colcon test passes.

## Notes for reviewers

None.

## Effects on system behavior

None.
